### PR TITLE
Improve the install script

### DIFF
--- a/docs/users_guide.md
+++ b/docs/users_guide.md
@@ -18,6 +18,7 @@ $ [VAR=VALUE] bash -c "$(curl -fsSL https://raw.githubusercontent.com/junaruga/r
 | PYTHON | Path to python | python3 |
 | RPM | Path to rpm | rpm |
 | RPM_VERSION | Installed python module's version | Same version with rpm |
+| VERBOSE | Verbose mode. true/false | false |
 
 
 ## Note
@@ -35,8 +36,13 @@ $ [VAR=VALUE] bash -c "$(curl -fsSL https://raw.githubusercontent.com/junaruga/r
   $ pip install --no-cache-dir rpm-py-installer
   ```
 
-- If you want to install the Python binding module on system Python (`/usr/bin/python{3,2,})`, install it manually from the RPM package(`python{3,2}-rpm`).
+- following package are required on Fedora.
+  - rpm-libs
+  - rpm-devel
 
+  See installed packages in [Dockerfile for testing](../tests/docker/Dockerfile) for detail.
+
+- If you want to install the Python binding module on system Python (`/usr/bin/python{3,2,})`, install it manually from the RPM package(`python{,2,3}-rpm`).
 
 ## Tutorial
 

--- a/install
+++ b/install
@@ -1,35 +1,73 @@
 #!/bin/bash
 
-set -ex
+set -e
 
+echo "Installing..."
+
+# Verbose mode. Default: false.
+VERBOSE="${VERBOSE:=false}"
+SETUP_PY_OPTS="-q"
+CURL_OPTS="--silent"
+if [ "${VERBOSE}" = true ]; then
+    set -x
+    SETUP_PY_OPTS="-v"
+    CURL_OPTS=""
+fi
 # Python's path that the module is installed on. Default: python3
 PYTHON="${PYTHON:=python3}"
 PYTHON="$(which "${PYTHON}")"
 # Linked rpm's path. Default: rpm.
 RPM="${RPM:=rpm}"
+RPM="$(which "${RPM}")"
 # Installed RPM Python module's version. Default: Same version with rpm.
 DEFAULT_RPM_VERSION=$("${RPM}" --version | cut -d' ' -f 3)
 RPM_VERSION="${RPM_VERSION:=${DEFAULT_RPM_VERSION}}"
 
-# Check system Python
+# Check if Python is system Python.
 if [[ "${PYTHON}" =~ ^/usr/bin/python.*$ ]]; then
-    cat <<EOF
-This tool does not install the Python module on system Python: ${PYTHON}.
-Install the module maually from the RPM package by dnf or yum command.
+    # Check the Python binding is not installed.
+    RESULT=$("${PYTHON}" -m pip list)
+    if ! echo "${RESULT}" | grep -E '^rpm(-python)? +' -q; then
+        cat 1>&2 <<EOF
+Skipped installing RPM python binding on system Python: ${PYTHON}.
+Install it manually by "dnf install python{,2,3}-rpm".
+Then run this installer again.
 EOF
-    exit 1
+        exit 1
+    fi
 fi
 
-WORK_DIR="$(pwd)/tmp/rpm-py-installer"
-if [ -d "${WORK_DIR}" ]; then
-    rm -rf "${WORK_DIR}"
+# If RPM is System installed RPM
+if [ "${RPM}" = "/usr/bin/rpm" ]; then
+    # Check if rpm-libs is installed for /usr/lib64/librpm*.so
+    if ! rpm -q rpm-libs --quiet; then
+        cat 1>&2 <<EOF
+rpm-libs is not installed.
+Install it by "dnf install rpm-libs".
+EOF
+        exit 2
+    fi
+
+    # Check rpm-devel is installed for /usr/lib64/pkgconfig/rpm.pc
+    if ! rpm -q rpm-devel --quiet; then
+        cat 1>&2 <<EOF
+rpm-devel is not installed.
+Install it by "dnf install rpm-devel".
+EOF
+        exit 2
+    fi
 fi
-mkdir -p "${WORK_DIR}"
+
+WORK_DIR="$(mktemp -d --suffix="-rpm-py-installer")"
+echo "Created working directory '${WORK_DIR}'"
 cd "${WORK_DIR}"
 
 RPM_REPO_URL='https://github.com/rpm-software-management/rpm'
 RPM_NAME="rpm-${RPM_VERSION}-release"
-curl -L "${RPM_REPO_URL}/archive/${RPM_NAME}.tar.gz" | tar xz
+ARCHIVE_FILE="${RPM_REPO_URL}/archive/${RPM_NAME}.tar.gz"
+
+echo "Downloading archive '${ARCHIVE_FILE}' in the working directory."
+curl --location ${CURL_OPTS} "${ARCHIVE_FILE}" | tar xz
 
 cd "rpm-${RPM_NAME}/python"
 
@@ -39,18 +77,15 @@ sed -e 's/@PACKAGE_NAME@/rpm/g' \
     setup.py.in \
     > setup.py
 
-# If you can not build, check below files.
-# $ rpm -ql rpm-libs
-# $ ls /usr/lib64/librpm*.so
+# rpm-libs and rpm-devel are required to build.
+echo "Building the Python binding module on Python: '${PYTHON}'."
+"${PYTHON}" setup.py ${SETUP_PY_OPTS} build
+"${PYTHON}" setup.py ${SETUP_PY_OPTS} install
 
-"${PYTHON}" setup.py build
-"${PYTHON}" setup.py install
+# Check the Python binding is installed.
+INSTALLED_RPM_PY=$("${PYTHON}" -m pip list | grep -E '^rpm(-python)? +')
+echo "RPM Python binding module installed: ${INSTALLED_RPM_PY}"
 
-# Below command is fine for the build?
-# pip install -e .
-
-"${PYTHON}" -m pip list | grep -E '^rpm(-python)? +'
-
-echo "PRM Python binding module is installed successfully."
+echo "Done successfully."
 
 exit 0


### PR DESCRIPTION
* Remove "set -x" when normal mode.
* Add check for rpm-libs and rpm-devel.
* Stop installing if the Python is system Python, and the Python binding is not installed on the system.
