### PR TITLE
Add environment option SETUP_PY_OPTIM.

### DIFF
--- a/docs/users_guide.md
+++ b/docs/users_guide.md
@@ -17,6 +17,7 @@ $ [VAR=VALUE] /path/to/python -c "$(curl -fsSL https://raw.githubusercontent.com
 | ---- | ----------- | ----- | ------- |
 | RPM | Path to rpm | /path/to/rpm | rpm |
 | RPM_PY_VERSION | Installed python module's version | N.N.N.N |  Same version with rpm |
+| SETUP_PY_OPTM | Use optimized `setup.py` for the Python binding for comfort install? Or Set "false" to use original one. | true/false | true |
 | VERBOSE | Verbose mode? | true/false | false |
 | WORK_DIR_REMOVED | Remove work directory? Set "false" to see used archive. | true/false | true |
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -54,6 +54,7 @@ def test_app_init(app):
     assert 'rpm' in app.rpm_path
     assert app.rpm_py_version
     assert re.match('^[\d.]+$', app.rpm_py_version)
+    assert app.setup_py_optimized is True
     assert app.setup_py_opts == '-q'
     assert app.curl_opts == '--silent'
     assert app.is_work_dir_removed is True
@@ -69,6 +70,16 @@ def test_app_init_env_rpm(app_with_env):
 def test_app_init_env_rpm_py_version(app_with_env):
     assert app_with_env
     assert app_with_env.rpm_py_version == '1.2.3'
+
+
+@pytest.mark.parametrize('env', [
+    {'SETUP_PY_OPTM': 'true'},
+    {'SETUP_PY_OPTM': 'false'},
+])
+def test_app_init_env_setup_py_optm(app_with_env, env):
+    assert app_with_env
+    value = True if env['SETUP_PY_OPTM'] == 'true' else False
+    assert app_with_env.setup_py_optimized is value
 
 
 @pytest.mark.parametrize('env', [{'VERBOSE': 'true'}])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -42,7 +42,8 @@ def test_install_failed_on_sys_python(install_script_path, python_path):
 def test_install_and_uninstall_are_ok_on_non_sys_python(install_script_path):
     python_path = sys.executable
     exit_status = _run_install_script(python_path, install_script_path,
-                                      VERBOSE='false')
+                                      VERBOSE='false',
+                                      WORK_DIR_REMOVED='true')
     assert exit_status == 0
 
     is_installed = _is_rpm_py_installed(python_path)


### PR DESCRIPTION
To use optimized setup.py for the Python bindings.
Use setuptools in setup.py to prevent deprecation message
when uninstalling the Python bindings.

Contribution to upstream is here.

```
https://github.com/rpm-software-management/rpm/pull/323
```
