### PR TITLE
Remove "which" command dependency for Python < 3.3.

### DIFF
--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -12,10 +12,17 @@ RUN mv RPM-GPG-KEY-fedora-28-primary /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-28-x86_
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-28-x86_64
 
 RUN dnf -y update
-# rpm-devel: rpm.pc used for "python setup.py build".
-# which: Used in install.py, scripts/lint_bash.sh
-# ShellCheck: Used in scripts/lint_bash.sh
-# python2-devel is not available on f25.
+# RPM packages for installing.
+# - rpm-libs
+# - rpm-devel: rpm.pc used for "python setup.py build".
+# - redhat-rpm-config
+# - gcc
+# - python{3,}-devel
+#   python2-devel is not available on f25.
+#
+# RPM packages for testing.
+# - which: Used in scripts/lint_bash.sh
+# - ShellCheck: Used in scripts/lint_bash.sh
 RUN dnf -y install \
   rpm-libs \
   rpm-devel \

--- a/.travis/Dockerfile.centos
+++ b/.travis/Dockerfile.centos
@@ -17,7 +17,6 @@ RUN yum -y install \
   python-devel \
   /usr/bin/python3.4 \
   /usr/bin/python2.7 \
-  which \
   && yum clean all
 RUN python3 -m ensurepip
 RUN python3 -m pip install --upgrade pip setuptools

--- a/install.py
+++ b/install.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import tempfile
 from contextlib import contextmanager
+from distutils.spawn import find_executable
 
 
 class Application(object):
@@ -342,8 +343,7 @@ class Cmd(object):
         if sys.version_info >= (3, 3):
             abs_path_cmd = shutil.which(cmd)
         else:
-            abs_path_cmd = cls.sh_e_out('which {0}'.format(cmd))
-            abs_path_cmd = abs_path_cmd.rstrip()
+            abs_path_cmd = find_executable(cmd)
         return abs_path_cmd
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -51,6 +51,12 @@ def test_cmd_cd_is_ok():
         assert cwd == tmp_dir
 
 
+@pytest.mark.parametrize('cmd', ['rpm', 'curl'])
+def test_cmd_which_is_ok(cmd):
+    abs_path = Cmd.which(cmd)
+    assert re.match('^/.*{0}$'.format(cmd), abs_path)
+
+
 def test_app_init(app):
     assert app
     assert app.verbose is False


### PR DESCRIPTION
This fixes https://github.com/junaruga/rpm-py-installer/issues/50 .