### PR TITLE
Remove shebang from install.py.

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import json
 import os
 import re


### PR DESCRIPTION
Always executed like `$ /path/to/python install.py` .