### PR TITLE
Add feature to get the Pythong binding source by "git clone".

### DIFF
--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -19,6 +19,8 @@ RUN dnf -y update
 # - gcc
 # - python{3,}-devel
 #   python2-devel is not available on f25.
+# - git: Used to get the rpm-python by git commmand,
+#        if a target rpm archive URL is not found on the server.
 #
 # RPM packages for testing.
 # - which: Used in scripts/lint_bash.sh
@@ -33,6 +35,7 @@ RUN dnf -y install \
   /usr/bin/python3.6 \
   /usr/bin/python3.5 \
   /usr/bin/python2.7 \
+  /usr/bin/git \
   which \
   ShellCheck \
   && dnf clean all

--- a/.travis/Dockerfile.centos
+++ b/.travis/Dockerfile.centos
@@ -17,6 +17,7 @@ RUN yum -y install \
   python-devel \
   /usr/bin/python3.4 \
   /usr/bin/python2.7 \
+  /usr/bin/git \
   && yum clean all
 RUN python3 -m ensurepip
 RUN python3 -m pip install --upgrade pip setuptools

--- a/docs/users_guide.md
+++ b/docs/users_guide.md
@@ -17,6 +17,7 @@ $ [VAR=VALUE] /path/to/python -c "$(curl -fsSL https://raw.githubusercontent.com
 | ---- | ----------- | ----- | ------- |
 | RPM | Path to rpm | /path/to/rpm | rpm |
 | RPM_PY_VERSION | Installed python module's version | N.N.N.N |  Same version with rpm |
+| GIT_BRANCH | Branch name for [RPM git repo](https://github.com/rpm-software-management/rpm). If this option is set, `rpm-py-installer` downloads the RPM source by `git clone` rather than downloading the archive file to get the Python binding. | ex. master, rpm-4.14.x | None |
 | SETUP_PY_OPTM | Use optimized `setup.py` for the Python binding for comfort install? Or Set "false" to use original one. | true/false | true |
 | VERBOSE | Verbose mode? | true/false | false |
 | WORK_DIR_REMOVED | Remove work directory? Set "false" to see used archive. | true/false | true |


### PR DESCRIPTION
Also added option GIT_BRANCH environment variable to specify the edge of the branch.

This fixes https://github.com/junaruga/rpm-py-installer/issues/51 .

About https://github.com/junaruga/rpm-py-installer/issues/45 , I implemented specifying branch name as a environment option in this PR, not general commit hash reference or not tag.
Because downloading source by "git clone -b branch_name --depth 1" is not heavy.

Modified doc: https://github.com/junaruga/rpm-py-installer/blob/feature/get-source-by-git-ref/docs/users_guide.md