### PR TITLE
Improve pytest settings.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+# https://coverage.readthedocs.io/en/latest/config.html
+[run]
+include =
+    rpm_py_installer/*
+    install.py
+    setup.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,1 +1,5 @@
+[tool:pytest]
+addopts = -s -v
+testpaths = tests
+
 [isort]

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
 commands =
     # We do not do coverage test for install.py.
     # https://github.com/pytest-dev/pytest-cov/issues/88
-    pytest -s -v -m 'not integration' --cov rpm_py_installer --cov-report term --cov-report html {posargs} tests
+    pytest -m 'not integration' --cov-config .coveragerc --cov . --cov-report term --cov-report html {posargs}
 
 [testenv:intg]
 deps =
@@ -17,7 +17,7 @@ deps =
 whitelist_externals =
     bash
 commands =
-    pytest -s -v -m 'integration' {posargs} tests
+    pytest -m 'integration' {posargs}
 
 [lint]
 skip_install = true


### PR DESCRIPTION
This fixes https://github.com/junaruga/rpm-py-installer/issues/58

* `install.py` included as a coverage target file.
* Define common pytest options in `setup.cfg`.

