### PR TITLE
Add {postargs} to tox.ini again.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -s -v
+addopts = -v
 testpaths = tests
 
 [isort]

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,10 @@ envlist = lint-py3,lint-py2,py36,py35,py34,py27
 # Do not run actual install process in tox.
 skipsdist = True
 
+# {posargs}: Arguments after $ tox options --.
+# See http://tox.readthedocs.io/en/latest/example/general.html
+# ex. to test only tests/test_something.py, outputting stdout/stderr (-s).
+# $ tox -e py36 -- -s tests/test_something.py
 [testenv]
 deps =
     -rtest-requirements.txt
@@ -12,7 +16,8 @@ commands =
         --cov-config .coveragerc \
         --cov . \
         --cov-report term \
-        --cov-report html
+        --cov-report html \
+        {posargs}
 
 [testenv:intg]
 deps =
@@ -20,7 +25,7 @@ deps =
 whitelist_externals =
     bash
 commands =
-    pytest -m 'integration'
+    pytest -m 'integration' {posargs}
 
 [lint]
 skip_install = true


### PR DESCRIPTION
Remove pytest -s option (no stdout/stderr capture) from default settings.

Ref: {postargs}: http://tox.readthedocs.io/en/latest/example/general.html
