### PR TITLE
Add check for rpm command, and improve tests (+py37 in tox.ini).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,27 @@
 language: generic
 sudo: required
 services: docker
-env:
-  # https://hub.docker.com/_/fedora/
-  - CONTAINER_IMAGE=fedora:26 TOXENV=lint-py3,lint-py2,py36,py35,py27
-  - CONTAINER_IMAGE=fedora:25 TOXENV=py36
-  - CONTAINER_IMAGE=fedora:rawhide TOXENV=py36,py27
-  # https://hub.docker.com/r/junaruga/rpm-py-installer-docker/
-  - CONTAINER_IMAGE=junaruga/rpm-py-installer-docker:26 TOXENV=intg
-  # https://hub.docker.com/_/centos/
-  - CONTAINER_IMAGE=centos:7 TOXENV=py34,py27
+matrix:
+  include:
+    # https://hub.docker.com/_/fedora/
+    - env: CONTAINER_IMAGE=fedora:26 TOXENV=lint-py3,lint-py2,py36,py35,py27
+    - env: CONTAINER_IMAGE=fedora:25 TOXENV=py36
+    - env: CONTAINER_IMAGE=fedora:rawhide TOXENV=py36,py27
+    # https://hub.docker.com/r/junaruga/rpm-py-installer-docker/
+    - env: CONTAINER_IMAGE=junaruga/rpm-py-installer-docker:26 TOXENV=intg
+    # https://hub.docker.com/_/centos/
+    - env: CONTAINER_IMAGE=centos:7 TOXENV=py34,py27
+  allow_failures:
+    - env: CONTAINER_IMAGE=fedora:rawhide TOXENV=py36,py27
+    - language: python
+      python: nightly
+  fast_finish: true
 install:
+  - |
+    if [ "${CONTAINER_IMAGE}" = "" ]; then
+        echo "Container image not defined." 1>&2
+        exit 1
+    fi
   - |
     DOCKER_FILE=.travis/Dockerfile
     if [[ "${CONTAINER_IMAGE}" =~ centos ]]; then
@@ -30,10 +41,7 @@ script:
         -e TOXENV="${TOXENV}" \
         -t \
         rpm-py-installer
+
 branches:
   only:
     - master
-matrix:
-  allow_failures:
-    - env: CONTAINER_IMAGE=fedora:rawhide TOXENV=py36,py27
-  fast_finish: true

--- a/install.py
+++ b/install.py
@@ -73,6 +73,8 @@ class Application(object):
         # Linked rpm's path. Default: rpm.
         rpm_path = os.environ.get('RPM', 'rpm')
         rpm_path = Cmd.which(rpm_path)
+        if not rpm_path:
+            raise InstallError('rpm command not found. Install rpm.')
 
         # Installed RPM Python module's version.
         # Default: Same version with rpm.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Common functions and a list of pytest.fixture here."""
 
+import getpass
 import os
 import shutil
 import sys
@@ -12,6 +13,16 @@ install_path = os.path.abspath('install.py')
 sys.path.insert(0, install_path)
 
 pytest_plugins = ['helpers_namespace']
+
+running_user = getpass.getuser()
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if item.get_marker('integration') is not None:
+            pass
+        else:
+            item.add_marker(pytest.mark.unit)
 
 
 @pytest.fixture
@@ -36,6 +47,11 @@ def tar_gz_file_path():
 @pytest.fixture
 def invalid_tar_gz_file_path():
     return os.path.abspath('tests/fixtures/invalid.tar.gz')
+
+
+@pytest.helpers.register
+def is_root_user():
+    return running_user == 'root'
 
 
 @pytest.helpers.register

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,11 +9,12 @@ import sys
 import pytest
 
 
-# Need root authority
 @pytest.mark.integration
 @pytest.mark.parametrize('python_path', (
     '/usr/bin/python3', '/usr/bin/python')
 )
+@pytest.mark.skipif(not pytest.helpers.is_root_user(),
+                    reason='needs root authority.')
 def test_install_failed_on_sys_python(install_script_path, python_path):
     # Case 1: rpm-py is installed on system Python.
     # Check rpm binding has already been installed before test.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint-py3,lint-py2,py36,py35,py34,py27
+envlist = lint-py3,lint-py2,py37,py36,py35,py34,py27
 # Do not run actual install process in tox.
 skipsdist = True
 
@@ -12,7 +12,7 @@ deps =
     -rtest-requirements.txt
 commands =
     pytest \
-        -m 'not integration' \
+        -m unit \
         --cov-config .coveragerc \
         --cov . \
         --cov-report term \
@@ -25,7 +25,7 @@ deps =
 whitelist_externals =
     bash
 commands =
-    pytest -m 'integration' {posargs}
+    pytest -m integration {posargs}
 
 [lint]
 skip_install = true


### PR DESCRIPTION
This PR is inherited from https://github.com/junaruga/rpm-py-installer/pull/71

I gave up to add py37 (Python nightly environment) on Travis.
But only added py37 to `tox.ini`. And I tested it on my local.

* Add py37 environment to `tox.ini`.
* Add pytest maker "unit" as normal marker.
  Now tests belongs to "unit" or "integration". No duplication.
  The idea is from https://github.com/pypa/pip/blob/master/tests/conftest.py def pytest_collection_modifyitems.
* Improve Application fixture.
* Improve integration test that needs root authority.