### PR TITLE
Remove popt-devel dependency.

### DIFF
--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -33,9 +33,6 @@ RUN dnf -y install \
   'dnf-command(download)' \
   # Used if downloading and extracting build dependency packages in installing.
   /usr/bin/cpio \
-  # popt.h (popt-devel) is used in rpmlib.h
-  # if building without rpm-devel package.
-  /usr/include/popt.h \
   # -- RPM packages for testing --
   # Used in scripts/lint_bash.sh
   which \

--- a/.travis/Dockerfile.centos
+++ b/.travis/Dockerfile.centos
@@ -22,7 +22,6 @@ RUN yum -y install \
   rpm-build-libs \
   /usr/bin/yumdownloader \
   /usr/bin/cpio \
-  /usr/include/popt.h \
   && yum clean all
 RUN python3 -m ensurepip
 RUN python3 -m pip install --upgrade pip setuptools

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -47,13 +47,11 @@ def test_install_and_uninstall_are_ok_on_non_sys_python(install_script_path):
 # rpm-build-libs might be always installed,
 # Because when running "dnf remove rpm-build-libs", "dnf" itself was removed.
 @pytest.mark.parametrize('is_rpm_devel, is_downloadable, is_rpm_build_libs', [
-    (True, False, True),
     (False, True, True),
-    (False, False, True),
+    (True, False, True),
 ], ids=[
-    'rpm-devel installed',
     'rpm-devel not installed, RPM package downloadable',
-    'rpm-devel not installed, rpm-build-lib installed',
+    'rpm-devel installed',
 ])
 @pytest.mark.skipif(not pytest.helpers.is_root_user(),
                     reason='needs root authority.')
@@ -64,24 +62,24 @@ def test_install_and_uninstall_are_ok_on_sys_status(
     if is_rpm_devel:
         _run_cmd('{0} -y install rpm-devel'.format(pkg_cmd))
     else:
-        _run_cmd('{0} -y remove rpm-devel'.format(pkg_cmd))
+        _run_cmd('{0} -y remove rpm-devel popt-devel'.format(pkg_cmd))
 
     if is_downloadable:
         _install_rpm_download_utility(is_dnf)
     else:
         _uninstall_rpm_download_utility(is_dnf)
 
-    if is_rpm_build_libs:
-        _run_cmd('{0} -y install rpm-build-libs'.format(pkg_cmd))
-    else:
-        _run_cmd('{0} -y remove rpm-build-libs'.format(pkg_cmd))
+    # if is_rpm_build_libs:
+    #     _run_cmd('{0} -y install rpm-build-libs'.format(pkg_cmd))
+    # else:
+    #     _run_cmd('{0} -y remove rpm-build-libs'.format(pkg_cmd))
 
     _assert_install_and_uninstall(install_script_path)
 
     # Reset as default system status.
-    _run_cmd('{0} -y remove rpm-devel'.format(pkg_cmd))
+    _run_cmd('{0} -y remove rpm-devel popt-devel'.format(pkg_cmd))
     _install_rpm_download_utility(is_dnf)
-    _run_cmd('{0} -y install rpm-build-libs'.format(pkg_cmd))
+    # _run_cmd('{0} -y install rpm-build-libs'.format(pkg_cmd))
 
     assert True
 


### PR DESCRIPTION
Related to https://github.com/junaruga/rpm-py-installer/issues/79 .

- Change RPM download command format to specify arch string.
  Below commands are used.
  - dnf download popt-devel.x86_64
  - yumdownloader popt-devel.x86_64
