### PR TITLE
Fix for updated flake8 3.5.0.

### DIFF
--- a/install.py
+++ b/install.py
@@ -895,7 +895,7 @@ class Cmd(object):
         except Exception as e:
             try:
                 proc.kill()
-            except:
+            except Exception:
                 pass
             raise e
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@ backports.unittest_mock
 # Coverage
 pytest-cov
 # Code Analysis for Python
-flake8
+flake8==3.5.0
 flake8-colors
 flake8-isort
 pydocstyle


### PR DESCRIPTION
* Flake8 was updated from 3.4.1 to 3.5.0.
* This fixes the new validation "E722 do not use bare except".
* Use fixed flake8's version to keep same condition.
