### PR TITLE
Supress an error log when the command returns non zero status.

### DIFF
--- a/install.py
+++ b/install.py
@@ -886,7 +886,6 @@ class Cmd(object):
                     cmd, returncode, os.getcwd())
                 if stderr is not None:
                     message += ' Stderr: [{0}]'.format(stderr)
-                Log.error(message)
                 raise InstallError(message)
 
             if stdout is not None:


### PR DESCRIPTION
Because it can be normal case to check the condition.

This PR fixes https://github.com/junaruga/rpm-py-installer/issues/91 .

```
$ sudo dnf remove rpm-devel popt-devel

$ pwd
/home/jaruga/git/rebase-helper

$ python3 -m venv ./venv

$ source venv/bin/activate

(venv) $ pip list
Package    Version
---------- -------
pip        9.0.1--
setuptools 28.8.0-

(venv) $ python -c "$(curl -fsSL --no-sessionid https://raw.githubusercontent.com/junaruga/rpm-py-installer/hotfix/supress-cmd-error-log-for-normal-case/install.py)"
[INFO] Installing...
[INFO] Created working directory '/tmp/tmpxy4xwin9-rpm-py-installer'
[INFO] Downloading archive. 'https://github.com/rpm-software-management/rpm/archive/rpm-4.13.0.1-release.tar.gz'.
Last metadata expiration check: 0:13:22 ago on Fri Nov  3 14:40:52 2017.
popt-devel-1.16-12.fc25.x86_64.rpm                            128 kB/s |  28 kB     00:00----
[INFO] Removed working directory '/tmp/tmpxy4xwin9-rpm-py-installer'
[INFO] Done successfully.

(venv) $ pip list
Package    Version 
---------- --------
pip        9.0.1   
rpm-python 4.13.0.1
setuptools 28.8.0 
```

`[ERROR]` logs do not exist in the output log.
