### PR TITLE
Add prefix RPM_PY_ to all environment variables

### DIFF
--- a/install.py
+++ b/install.py
@@ -52,7 +52,7 @@ class Application(object):
             Log.info("Saved working directory '{0}'".format(work_dir))
 
     def _load_options_from_env(self):
-        verbose = True if os.environ.get('VERBOSE') == 'true' else False
+        verbose = True if os.environ.get('RPM_PY_VERBOSE') == 'true' else False
         # Set it as early as possible for other functions.
         self.verbose = verbose
         Log.verbose = verbose
@@ -61,7 +61,7 @@ class Application(object):
         python = Python()
 
         # Linked rpm's path. Default: rpm.
-        rpm_path = os.environ.get('RPM', 'rpm')
+        rpm_path = os.environ.get('RPM_PY_RPM_BIN', 'rpm')
         rpm_path = Cmd.which(rpm_path)
         if not rpm_path:
             raise InstallError('rpm command not found. Install rpm.')
@@ -78,8 +78,8 @@ class Application(object):
 
         # Git branch name. Default: None
         git_branch = None
-        if 'GIT_BRANCH' in os.environ:
-            git_branch = os.environ.get('GIT_BRANCH')
+        if 'RPM_PY_GIT_BRANCH' in os.environ:
+            git_branch = os.environ.get('RPM_PY_GIT_BRANCH')
 
         # Use optimized setup.py?
         # Default: true
@@ -91,8 +91,8 @@ class Application(object):
                 optimized = False
 
         is_work_dir_removed = True
-        if 'WORK_DIR_REMOVED' in os.environ:
-            if os.environ.get('WORK_DIR_REMOVED') == 'true':
+        if 'RPM_PY_WORK_DIR_REMOVED' in os.environ:
+            if os.environ.get('RPM_PY_WORK_DIR_REMOVED') == 'true':
                 is_work_dir_removed = True
             else:
                 is_work_dir_removed = False

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -696,7 +696,7 @@ def test_app_init(app):
     assert app.is_work_dir_removed is True
 
 
-@pytest.mark.parametrize('env', [{'RPM': 'pwd'}])
+@pytest.mark.parametrize('env', [{'RPM_PY_RPM_BIN': 'pwd'}])
 def test_app_init_env_rpm(app):
     assert app
     assert re.match('^/.+/pwd$', app.rpm.rpm_path)
@@ -708,7 +708,7 @@ def test_app_init_env_rpm_py_version(app):
     assert app.rpm_py.version.version == '1.2.3'
 
 
-@pytest.mark.parametrize('env', [{'GIT_BRANCH': 'master'}])
+@pytest.mark.parametrize('env', [{'RPM_PY_GIT_BRANCH': 'master'}])
 def test_app_init_env_git_branch(app):
     assert app
     assert app.rpm_py.downloader.git_branch == 'master'
@@ -724,19 +724,19 @@ def test_app_init_env_setup_py_optm(app, env):
     assert app.rpm_py.installer.optimized is value
 
 
-@pytest.mark.parametrize('env', [{'VERBOSE': 'true'}])
+@pytest.mark.parametrize('env', [{'RPM_PY_VERBOSE': 'true'}])
 def test_app_init_env_verbose(app):
     assert app
     assert app.verbose is True
 
 
 @pytest.mark.parametrize('env', [
-    {'WORK_DIR_REMOVED': 'true'},
-    {'WORK_DIR_REMOVED': 'false'},
+    {'RPM_PY_WORK_DIR_REMOVED': 'true'},
+    {'RPM_PY_WORK_DIR_REMOVED': 'false'},
 ])
 def test_app_init_env_work_dir_removed(app, env):
     assert app
-    value = True if env['WORK_DIR_REMOVED'] == 'true' else False
+    value = True if env['RPM_PY_WORK_DIR_REMOVED'] == 'true' else False
     assert app.is_work_dir_removed is value
 
 


### PR DESCRIPTION
Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>

A solution to #104 . This can avoid rpm-py-installer environment variable conflicts with Jenkins Git plugin, for example `GIT_BRANCH`.