### PR TITLE
Add Travis retry script for stable docker build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - |
     sed -i "/^FROM / s|FROM .*|FROM ${CONTAINER_IMAGE}|" "${DOCKER_FILE}"
   - |
-    docker build \
+    travis_retry docker build \
         -t rpm-py-installer \
         -f "${DOCKER_FILE}" \
         .


### PR DESCRIPTION
Sometimes `docker build` fails because of network issue.
https://travis-ci.org/junaruga/rpm-py-installer/jobs/326738897

Add travis_retry function.
https://docs.travis-ci.com/user/common-build-problems/#travis_retry