### PR TITLE
Retrict isort version to test on Python 2.6.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,6 +9,9 @@ pytest-cov
 flake8==3.5.0
 flake8-colors
 flake8-isort
+# Restrict version to test on Python 2.6.
+# https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md
+isort<4.3
 pydocstyle
 # The pep8-naming is used as a plugin for flake8
 pep8-naming


### PR DESCRIPTION
This PR fixes https://github.com/junaruga/rpm-py-installer/issues/116
