### PR TITLE
Fix an issue that the coverage result includes files under the .tox/.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,9 @@ pytest-helpers-namespace
 backports.unittest_mock
 # Coverage
 pytest-cov
+# Restrict version for below issue.
+# https://github.com/junaruga/rpm-py-installer/issues/122
+coverage<4.5
 # Code Analysis for Python
 flake8==3.5.0
 flake8-colors


### PR DESCRIPTION
Fixes https://github.com/junaruga/rpm-py-installer/issues/122 .
This should be temporary workflow.

