### PR TITLE
Update .travis.yml for new Fedora 28 container image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ services: docker
 matrix:
   include:
     # https://hub.docker.com/_/fedora/
-    - env: CONTAINER_IMAGE=fedora:27 TOXENV=lint-py3,lint-py2,py36,py27
-    - env: CONTAINER_IMAGE=fedora:26 TOXENV=py35,py26
-    - env: CONTAINER_IMAGE=fedora:25 TOXENV=py36
+    - env: CONTAINER_IMAGE=fedora:28 TOXENV=lint-py3,lint-py2,py36,py27
+    - env: CONTAINER_IMAGE=fedora:27 TOXENV=py35,py26
+    - env: CONTAINER_IMAGE=fedora:26 TOXENV=py36
     - env: CONTAINER_IMAGE=fedora:rawhide TOXENV=py36,py27
     # https://hub.docker.com/r/junaruga/rpm-py-installer-docker/
     - env: CONTAINER_IMAGE=junaruga/rpm-py-installer-docker:26 TOXENV=intg


### PR DESCRIPTION
New f28 container image was released. And f25 was dropped.
https://hub.docker.com/_/fedora/
