### PR TITLE
Change downloading server priority to 1st: GitHub 2nd: rpm.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ matrix:
     - env: CONTAINER_IMAGE=fedora:28 TOXENV=lint-py3,lint-py2,py36,py27
     - env: CONTAINER_IMAGE=fedora:27 TOXENV=py35,py26
     - env: CONTAINER_IMAGE=fedora:26 TOXENV=py36
-    - env: CONTAINER_IMAGE=fedora:rawhide TOXENV=py37,py36,py27
+    - env: CONTAINER_IMAGE=fedora:rawhide TOXENV=py37,py27
     # https://hub.docker.com/r/junaruga/rpm-py-installer-docker/
     - env: CONTAINER_IMAGE=junaruga/rpm-py-installer-docker:26 TOXENV=intg
     # https://hub.docker.com/_/centos/
     - env: CONTAINER_IMAGE=centos:7 TOXENV=py34,py27
     - env: CONTAINER_IMAGE=centos:6 TOXENV=py27,py26
   allow_failures:
-    - env: CONTAINER_IMAGE=fedora:rawhide TOXENV=py37,py36,py27
+    - env: CONTAINER_IMAGE=fedora:rawhide TOXENV=py37,py27
   fast_finish: true
 install:
   - |

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -17,7 +17,6 @@ RUN dnf -y install \
   # python2-devel is not available on f25.
   python-devel \
   /usr/bin/python3.7 \
-  /usr/bin/python3.6 \
   /usr/bin/python3.5 \
   /usr/bin/python2.7 \
   /usr/bin/python2.6 \
@@ -32,6 +31,12 @@ RUN dnf -y install \
   # Used if downloading and extracting build dependency packages in installing.
   /usr/bin/cpio
   # -- RPM packages for testing --
+
+# Temporary workflow to install python3.6 on rawhide.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1601113
+RUN dnf -y install /usr/bin/python3.6 || true
+RUN dnf -y install /usr/bin/python3 || true
+
 RUN ./.travis/dnf_install_lint_pkgs.sh
 RUN dnf clean all
 RUN python3 -m ensurepip

--- a/install.py
+++ b/install.py
@@ -417,21 +417,23 @@ class Downloader(object):
     def _get_candidate_archive_dicts(self):
         archive_dicts = []
 
-        if self.rpm_py_version.is_release:
-            url = self._get_rpm_org_archive_url()
-            top_dir_name = self._get_rpm_org_archive_top_dir_name()
-            archive_dicts.append({
-                'site': 'rpm.org',
-                'url': url,
-                'top_dir_name': top_dir_name,
-            })
-
         tag_names = self._predict_candidate_git_tag_names()
         for tag_name in tag_names:
             url = self._get_git_hub_archive_url(tag_name)
             top_dir_name = self._get_git_hub_archive_top_dir_name(tag_name)
             archive_dicts.append({
                 'site': 'github',
+                'url': url,
+                'top_dir_name': top_dir_name,
+            })
+
+        # Set rpm.org server as a secondary server, because it takes long time
+        # to download an archive. GitHub is better to download the archive.
+        if self.rpm_py_version.is_release:
+            url = self._get_rpm_org_archive_url()
+            top_dir_name = self._get_rpm_org_archive_top_dir_name()
+            archive_dicts.append({
+                'site': 'rpm.org',
                 'url': url,
                 'top_dir_name': top_dir_name,
             })

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -563,12 +563,6 @@ def test_downloader_download_and_expand_from_archive_url(
         '4.13.0',
         [
             {
-                'site': 'rpm.org',
-                'url': 'http://ftp.rpm.org/releases/'
-                       'rpm-4.13.x/rpm-4.13.0.tar.gz',
-                'top_dir_name': 'rpm-4.13.0',
-            },
-            {
                 'site': 'github',
                 'url': 'https://github.com/rpm-software-management/rpm'
                        '/archive/rpm-4.13.0-release.tar.gz',
@@ -579,6 +573,12 @@ def test_downloader_download_and_expand_from_archive_url(
                 'url': 'https://github.com/rpm-software-management/rpm'
                        '/archive/rpm-4.13.0.tar.gz',
                 'top_dir_name': 'rpm-rpm-4.13.0',
+            },
+            {
+                'site': 'rpm.org',
+                'url': 'http://ftp.rpm.org/releases/'
+                       'rpm-4.13.x/rpm-4.13.0.tar.gz',
+                'top_dir_name': 'rpm-4.13.0',
             },
         ],
     ),


### PR DESCRIPTION
This is related to https://github.com/junaruga/rpm-py-installer/issues/110#issuecomment-404670655 .

Right now rpm.org sever is heavy to download.
It takes 30+ seconds to download the RPM source archive.
It can cause timeout of setuptools to run `rpm-py-installer` internally in the case of a Python package is installed from PyPI as a dependency of `rpm-py-installer`.
