### PR TITLE
Remove libpopt-dev dependency on Ubuntu.

### DIFF
--- a/.travis/Dockerfile.ubuntu
+++ b/.travis/Dockerfile.ubuntu
@@ -11,11 +11,8 @@ RUN apt-get install -y \
   python3.4-dev \
   python2.7-dev \
   python3-pip \
-  # Required to build RPM Python binding.
-  libpopt-dev \
   # -- RPM packages required for a specified case --
-  git \
-  cpio
+  git
 RUN apt-get clean all
 RUN python3 -m pip install tox
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -760,12 +760,14 @@ def test_installer_make_dep_lib_file_links_and_copy_include_files(installer):
     with pytest.raises(InstallError) as ei:
         installer._make_dep_lib_file_sym_links_and_copy_include_files()
     expected_message = '''
-Required RPM not installed: [popt-devel],
-when a RPM download plugin not installed.
-'''
+Install a {0} download plugin or
+install the {0} pacakge [{1}].
+'''.format(installer.package_sys_name, installer.pacakge_popt_devel_name)
     assert expected_message == str(ei.value)
 
 
+@pytest.mark.skipif(pytest.helpers.is_debian(),
+                    reason='Only Linux Fedora.')
 def test_installer_run_raises_error_for_rpm_build_libs(installer):
     installer.rpm.has_composed_rpm_bulid_libs = mock.MagicMock(
         return_value=True


### PR DESCRIPTION
Fixes https://github.com/junaruga/rpm-py-installer/issues/142

Memo: I replaced `apt show package_name` because it does not return error exit status even when the package_name does not exist.