### PR TITLE
[WIP] Installing Python binding from system (RPM) package first.

### DIFF
--- a/install.py
+++ b/install.py
@@ -146,12 +146,9 @@ class RpmPy(object):
             self.installer.install_from_rpm_py_package()
         except InstallError as e:
             org_message = str(e)
-            message = '''
-Faild to install from RPM Python binding package.
-{0}
-Try to install from RPM source code.
-'''.format(org_message)
-            Log.warn(message)
+            Log.warn('Faild to install from RPM Python binding package.')
+            Log.warn(org_message)
+            Log.warn('Try to install from RPM source code. ')
 
             self.download_and_install_from_source()
 

--- a/install.py
+++ b/install.py
@@ -142,17 +142,27 @@ class RpmPy(object):
 
     def download_and_install(self):
         """Download and install RPM Python binding."""
+        try:
+            self.installer.install_from_rpm_py_package()
+        except InstallError as e:
+            org_message = str(e)
+            message = '''
+Faild to install from RPM Python binding package.
+{0}
+Try to install from RPM source code.
+'''.format(org_message)
+            Log.warn(message)
+
+            self.download_and_install_from_source()
+
+    def download_and_install_from_source(self):
+        """Download and install RPM Python binding from source."""
         top_dir_name = self.downloader.download_and_expand()
         rpm_py_dir = os.path.join(top_dir_name, 'python')
 
-        setup_py_in_found = False
         with Cmd.pushd(rpm_py_dir):
             if self.installer.setup_py.exists_in_path():
-                setup_py_in_found = True
                 self.installer.run()
-
-        if not setup_py_in_found:
-            self.installer.install_from_rpm_py_package()
 
 
 class RpmPyVersion(object):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -825,6 +825,7 @@ def test_rpm_py_download_and_install_src(setup_py_in_exists, sys_rpm_path):
             pytest.helpers.touch(os.path.join(python_dir, 'setup.py.in'))
         rpm_py.download_and_install()
 
+        assert rpm_py.installer.install_from_rpm_py_package.called
         if setup_py_in_exists:
             assert rpm_py.installer.run.called
         else:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -814,7 +814,7 @@ def test_rpm_py_download_and_install(setup_py_in_exists, sys_rpm_path):
         return_value=None
     )
     rpm_py.installer.install_from_rpm_py_package = mock.Mock(
-        return_value=None
+        side_effect=InstallError('Install failed from package.')
     )
 
     with pytest.helpers.work_dir():
@@ -824,12 +824,11 @@ def test_rpm_py_download_and_install(setup_py_in_exists, sys_rpm_path):
             pytest.helpers.touch(os.path.join(python_dir, 'setup.py.in'))
         rpm_py.download_and_install()
 
+        assert rpm_py.installer.install_from_rpm_py_package.called
         if setup_py_in_exists:
             assert rpm_py.installer.run.called
-            assert not rpm_py.installer.install_from_rpm_py_package.called
         else:
             assert not rpm_py.installer.run.called
-            assert rpm_py.installer.install_from_rpm_py_package.called
 
 
 def test_app_init(app):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -800,7 +800,7 @@ when a RPM download plugin not installed.
 
 
 @pytest.mark.parametrize('setup_py_in_exists', [True, False])
-def test_rpm_py_download_and_install(setup_py_in_exists, sys_rpm_path):
+def test_rpm_py_download_and_install_src(setup_py_in_exists, sys_rpm_path):
     version_str = '4.13.0'
     python = Python()
     linux = Linux.get_instance(python=python, rpm_path=sys_rpm_path)
@@ -813,6 +813,7 @@ def test_rpm_py_download_and_install(setup_py_in_exists, sys_rpm_path):
     rpm_py.installer.run = mock.Mock(
         return_value=None
     )
+    # Fails installation from package to test installation from source.
     rpm_py.installer.install_from_rpm_py_package = mock.Mock(
         side_effect=InstallError('Install failed from package.')
     )
@@ -824,7 +825,6 @@ def test_rpm_py_download_and_install(setup_py_in_exists, sys_rpm_path):
             pytest.helpers.touch(os.path.join(python_dir, 'setup.py.in'))
         rpm_py.download_and_install()
 
-        assert rpm_py.installer.install_from_rpm_py_package.called
         if setup_py_in_exists:
             assert rpm_py.installer.run.called
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
 commands =
     pytest \
         -m unit \
+        -s \
         --cov-config .coveragerc \
         --cov . \
         --cov-report term \


### PR DESCRIPTION
Related to https://github.com/junaruga/rpm-py-installer/issues/110

To speed up installing time on Fedora and CentOS.

Do it after fixing the issue: https://github.com/junaruga/rpm-py-installer/pull/149 .
It can be only change the flag to control "install from binary package" in this PR.
