### PR TITLE
Add the feature to install RPM Python binding from binary

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,12 +11,32 @@ from contextlib import contextmanager
 
 import pytest
 
+OS_RELEASE_FILE = '/etc/os-release'
+
 install_path = os.path.abspath('install.py')
 sys.path.insert(0, install_path)
 
 pytest_plugins = ['helpers_namespace']
 
 running_user = getpass.getuser()
+
+
+def _get_os_id():
+    os_id = None
+    if not os.path.isfile(OS_RELEASE_FILE):
+        return os_id
+
+    with open(OS_RELEASE_FILE) as f_in:
+        for line in f_in:
+            match = re.search(r'^ID=[\'"]?(\w+)?[\'"]?$', line)
+            if match:
+                os_id = match.group(1)
+                break
+
+    return os_id
+
+
+_os_id = _get_os_id()
 _is_dnf = True if os.system('dnf --version') == 0 else False
 _is_debian = True if os.system('apt-get --version') == 0 else False
 
@@ -34,9 +54,22 @@ def install_script_path():
     return install_path
 
 
+@pytest.fixture
+def is_fedora():
+    """Return if it is Fedora Linux."""
+    return _os_id == 'fedora'
+
+
+@pytest.fixture
+def is_centos():
+    """Return if it is CentOS Linux."""
+    return _os_id == 'centos'
+
+
 @pytest.helpers.register
 @pytest.fixture
 def is_debian():
+    """Return if it is Debian base Linux."""
     return _is_debian
 
 


### PR DESCRIPTION
Add the feature to install RPM Python binding from binary for every possible environment.

Add the environment variable `RPM_PY_INSTALL_BIN` (true/false, detaulf: false) to control it.

If `RPM_PY_INSTALL_BIN` is not set, the behavior is same with current one.

When `RPM_PY_INSTALL_BIN` is 'true',
1. Try to install from RPM Python binding binary package.
2. If it is failed for RPM Python binding package does not exist (on Ubuntu) or can not find the RPM Python binding package (on Fedora), try to install from the source code.
