### PR TITLE
Fix py26 virtualenv issue.

### DIFF
--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -36,8 +36,7 @@ RUN dnf -y --allowerasing install \
 RUN ./.travis/dnf_install_lint_pkgs.sh
 RUN dnf clean all
 RUN python3 -m ensurepip
-RUN python3 -m pip install --upgrade pip setuptools
-RUN python3 -m pip install tox
+RUN python3 -m pip install --upgrade -rtox-requirements.txt
 
 # fedora:25, 26 tox is installed to /usr/bin/tox
 # fedora:rawhide tox is installed to /usr/local/bin/tox

--- a/.travis/Dockerfile.centos
+++ b/.travis/Dockerfile.centos
@@ -24,7 +24,6 @@ RUN yum -y install \
   /usr/bin/cpio \
   && yum clean all
 RUN python3 -m ensurepip
-RUN python3 -m pip install --upgrade pip setuptools
-RUN python3 -m pip install tox
+RUN python3 -m pip install --upgrade -rtox-requirements.txt
 
 CMD ["/usr/bin/tox"]

--- a/.travis/Dockerfile.centos6
+++ b/.travis/Dockerfile.centos6
@@ -29,7 +29,6 @@ RUN ./.travis/install_python.sh 2.7.14
 ENV PATH "/usr/local/python-2.7.14/bin:${PATH}"
 
 RUN python2.7 -m ensurepip
-RUN python2.7 -m pip install --upgrade pip setuptools
-RUN python2.7 -m pip install tox
+RUN python2.7 -m pip install --upgrade -rtox-requirements.txt
 
 CMD ["/usr/local/python-2.7.14/bin/tox"]

--- a/install.py
+++ b/install.py
@@ -1011,7 +1011,7 @@ when a RPM download plugin not installed.
                 )
             if condition_from and condition_to:
                 package_name = None
-                if sys.version_info.major >= 3:
+                if sys.version_info >= (3, 0):
                     package_name = package_info.get('py3')
                 else:
                     package_name = package_info.get('py2')

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -821,7 +821,7 @@ def test_installer_predict_rpm_py_package_names(
     monkeypatch.setattr(type(installer.rpm), 'version_info',
                         mock.PropertyMock(return_value=rpm_version_info))
     expected_package_names = None
-    if sys.version_info.major >= 3:
+    if sys.version_info >= (3, 0):
         expected_package_names = package_names_py3
     else:
         expected_package_names = package_names_py2
@@ -903,7 +903,7 @@ def test_installer_install_from_rpm_py_package(
         # http://mirror.centos.org/centos/7/os/x86_64/Packages/
         if is_debian or \
            not installer._predict_rpm_py_package_names() or \
-           (is_centos and sys.version_info.major >= 3):
+           (is_centos and sys.version_info >= (3, 0)):
             with pytest.raises(RpmPyPackageNotFoundError):
                 installer.install_from_rpm_py_package()
         else:

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -1,0 +1,6 @@
+pip
+setuptools
+# For Python 2.6.
+# https://github.com/pypa/virtualenv/commit/73404cb
+virtualenv<16.0.0
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -34,9 +34,6 @@ whitelist_externals =
 commands =
     python --version
     rpm --version
-    curl -O https://bootstrap.pypa.io/get-pip.py
-    python get-pip.py --no-setuptools --no-wheel
-    rm -f get-pip.py
     pytest \
         -m unit \
         {posargs}


### PR DESCRIPTION
* virtualenv 16.0.0 dropped support for Python 2.6.
* Fix failed tests on py26. py26 is not correctly tested on Travis.