### PR TITLE
Restrict used tox version to test on Python 2.6.

### DIFF
--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -3,4 +3,7 @@ setuptools
 # For Python 2.6.
 # https://github.com/pypa/virtualenv/commit/73404cb
 virtualenv<16.0.0
-tox
+# For Python 2.6.
+# Upstream changed to use "python -m pip", but Pytyon 2.6 does not support it.
+# https://github.com/tox-dev/tox/commit/e057755
+tox<3.2


### PR DESCRIPTION
This pull-request enables to test on Python 2.6 again.

Fixes below error.

https://travis-ci.org/junaruga/rpm-py-installer/builds/422984523

```
cmdargs: ['/build/.tox/py26/bin/python', '-m', 'pip', 'install', '-rtest-requirements.txt']
/build/.tox/py26/bin/python: pip is a package and cannot be directly executed
```
