### PR TITLE
Update GPG keys first in case some of them are missing.

### DIFF
--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -7,6 +7,8 @@ COPY . .
 
 RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.conf
 
+# Update GPG keys first in case some of them are missing.
+RUN dnf -y --nogpgcheck update fedora-gpg-keys || true
 RUN dnf -y update
 RUN dnf -y --allowerasing install \
   # -- RPM packages required for installing --


### PR DESCRIPTION
This fixes current GPG Keys issues on Fedora rawhide.
https://travis-ci.org/junaruga/rpm-py-installer/jobs/423025698

```
Importing GPG key 0x429476B4:
 Userid     : "Fedora 29 (29) <fedora-29@fedoraproject.org>"
 Fingerprint: 5A03 B4DD 8254 ECA0 2FDA 1637 A20A A56B 4294 76B4
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-29-x86_64
Key imported successfully
Import of key(s) didn't help, wrong key(s)?
Public key for brotli-1.0.5-1.fc29.x86_64.rpm is not installed. Failing package is: brotli-1.0.5-1.fc29.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-29-x86_64
Public key for dbus-daemon-1.12.10-1.fc29.x86_64.rpm is not installed. Failing package is: dbus-daemon-1:1.12.10-1.fc29.x86_64
```

I referred rebase-helper's code.
https://github.com/rebase-helper/rebase-helper/blob/master/docker/Dockerfile.base
