### PR TITLE
Add an option to install the Python binding on the system Python.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     # https://hub.docker.com/r/junaruga/rpm-py-installer-docker/
     - env: CONTAINER_IMAGE=junaruga/rpm-py-installer-docker:26 TOXENV=intg
     # https://hub.docker.com/_/centos/
-    - env: CONTAINER_IMAGE=centos:7 TOXENV=py34,py27
+    - env: CONTAINER_IMAGE=centos:7 TOXENV=py36,py34,py27
     - env: CONTAINER_IMAGE=centos:6 TOXENV=py27,py26
     # https://hub.docker.com/_/ubuntu/
     - env: CONTAINER_IMAGE=ubuntu:bionic TOXENV=py36,py27

--- a/.travis/Dockerfile.centos
+++ b/.travis/Dockerfile.centos
@@ -13,8 +13,10 @@ RUN yum -y install \
   rpm-libs \
   redhat-rpm-config \
   gcc \
+  python36-devel \
   python34-devel \
   python-devel \
+  /usr/bin/python3.6 \
   /usr/bin/python3.4 \
   /usr/bin/python2.7 \
   # -- RPM packages required for a specified case --

--- a/docs/users_guide.md
+++ b/docs/users_guide.md
@@ -16,6 +16,7 @@ $ [VAR=VALUE] /path/to/python -c "$(curl -fsSL https://raw.githubusercontent.com
 | NAME | Description | Value | Default |
 | ---- | ----------- | ----- | ------- |
 | RPM_PY_INSTALL_BIN | Install RPM Python binding from binary package? | true/false | false |
+| RPM_PY_SYS | Install the Python binding on the system Python? | true/false | false |
 | RPM_PY_RPM_BIN | Path to rpm | /path/to/rpm | rpm |
 | RPM_PY_VERSION | Installed python module's version | N.N.N.N |  Same version with rpm |
 | RPM_PY_GIT_BRANCH | Branch name for [RPM git repo](https://github.com/rpm-software-management/rpm). If this option is set, `rpm-py-installer` downloads the RPM source by `git clone` rather than downloading the archive file to get the Python binding. | ex. master, rpm-4.14.x | None |

--- a/install.py
+++ b/install.py
@@ -64,6 +64,15 @@ class Application(object):
         if os.environ.get('RPM_PY_INSTALL_BIN') == 'true':
             is_installed_from_bin = True
 
+        # Install the Python binding on the system Python?
+        # Default: false
+        sys_installed = False
+        if 'RPM_PY_SYS' in os.environ:
+            if os.environ.get('RPM_PY_SYS') == 'true':
+                sys_installed = True
+            else:
+                sys_installed = False
+
         # Python's path that the module is installed on.
         python = Python()
 
@@ -75,7 +84,8 @@ class Application(object):
         if not rpm_path.endswith('rpm'):
             raise InstallError('Invalid rpm_path: {0}'.format(rpm_path))
 
-        linux = Linux.get_instance(python=python, rpm_path=rpm_path)
+        linux = Linux.get_instance(python=python, rpm_path=rpm_path,
+                                   sys_installed=sys_installed)
 
         # Installed RPM Python module's version.
         # Default: Same version with rpm.
@@ -1156,6 +1166,7 @@ class Linux(object):
 
         self.python = python
         self.rpm = self.create_rpm(rpm_path)
+        self.sys_installed = kwargs.get('sys_installed', False)
 
     @classmethod
     def get_instance(cls, python, rpm_path, **kwargs):
@@ -1188,10 +1199,13 @@ Nothing to do.
 '''
                 Log.info(message)
                 raise InstallSkipError(message)
+            elif self.sys_installed:
+                pass
             else:
                 message = '''
 RPM Python binding on system Python should be installed manually.
-Install the proper RPM package of python{,2,3}-rpm.
+Install the proper RPM package of python{,2,3}-rpm,
+or set a environment variable RPM_PY_SYS=true
 '''
                 raise InstallError(message)
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1032,6 +1032,7 @@ def test_app_init(app):
     assert app.linux
     assert isinstance(app.linux, Linux)
     assert app.linux.rpm
+    assert app.linux.sys_installed is False
     assert isinstance(app.linux.rpm, Rpm)
     assert app.rpm_py
     assert isinstance(app.rpm_py, RpmPy)
@@ -1101,6 +1102,12 @@ def test_app_verify_system_status_skipped_on_sys_py_and_installed_rpm_py(app):
     with pytest.raises(InstallSkipError):
         app.linux.verify_system_status()
 
+
+def test_app_verify_system_status_is_ok_on_sys_py_and_sys_installed_true(app):
+    app.python.is_system_python = mock.MagicMock(return_value=True)
+    app.python.is_python_binding_installed = mock.MagicMock(return_value=False)
+    app.linux.sys_installed = mock.MagicMock(return_value=True)
+    app.linux.verify_system_status()
     assert True
 
 
@@ -1111,7 +1118,8 @@ def test_app_verify_system_status_is_error_on_sys_py_and_no_rpm_py(app):
         app.linux.verify_system_status()
     expected_message = '''
 RPM Python binding on system Python should be installed manually.
-Install the proper RPM package of python{,2,3}-rpm.
+Install the proper RPM package of python{,2,3}-rpm,
+or set a environment variable RPM_PY_SYS=true
 '''
     assert expected_message == str(ei.value)
 


### PR DESCRIPTION
This fixes https://github.com/junaruga/rpm-py-installer/issues/174 .
Added the environment variable to install forcely the RPM Python binding on the system Python.

Ideally it should be detected and installed without the environment variable seeing the condition.
Such as if the python is system Python and Python version = 3.y and there is no `python3-rpm` or `python3y-rpm`, then install it on the system Python.
But it is a next phase.

https://github.com/junaruga/rpm-py-installer/tree/feature/force-install-on-system-python


