### PR TITLE
Change Python binding installed site-packages directory to arch site-packages

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -872,7 +872,11 @@ def test_installer_download_and_extract_rpm_py_package(installer, statuses):
 @pytest.mark.skipif(pytest.helpers.helper_is_debian(),
                     reason='Only Linux Fedora.')
 def test_fedora_installer_install_from_rpm_py_package(installer, monkeypatch):
-    dst_rpm_dir = 'dummy/dst/site-packages/rpm'
+    dst_rpm_dir = 'dummy/dst/lib64/pythonX.Y/site-packages/rpm'
+    rpm_dirs = [
+        dst_rpm_dir,
+        'dummy/dst/lib/pythonX.Y/site-packages/rpm'
+    ]
 
     def download_and_extract_side_effect(*args):
         py_dir_name = 'python{0}.{1}'.format(
@@ -882,10 +886,11 @@ def test_fedora_installer_install_from_rpm_py_package(installer, monkeypatch):
         )
         os.makedirs(downloaded_rpm_dir)
         pytest.helpers.touch(os.path.join(downloaded_rpm_dir, '__init__.py'))
-        os.makedirs(dst_rpm_dir)
 
     installer._download_and_extract_rpm_py_package = mock.Mock(
             side_effect=download_and_extract_side_effect)
+    monkeypatch.setattr(type(installer.python), 'python_lib_rpm_dirs',
+                        mock.PropertyMock(return_value=rpm_dirs))
     monkeypatch.setattr(type(installer.python), 'python_lib_rpm_dir',
                         mock.PropertyMock(return_value=dst_rpm_dir))
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -178,13 +178,18 @@ import shutil
 import sys
 from distutils.sysconfig import get_python_lib
 
-lib_dir = get_python_lib()
-rpm_dir = os.path.join(lib_dir, 'rpm')
-init_py = os.path.join(rpm_dir, '__init__.py')
-if os.path.isfile(init_py):
-    print('__init__.py {0} exists.'.format(init_py))
-else:
-    sys.exit('__init__.py {0} does not exist.'.format(init_py))
+lib_dirs = []
+lib_dirs.append(get_python_lib())
+lib_dirs.append(get_python_lib(plat_specific=True))
+is_installed = False
+for lib_dir in lib_dirs:
+    init_py = os.path.join(lib_dir, 'rpm', '__init__.py')
+    if os.path.isfile(init_py):
+        is_installed = True
+        print('__init__.py {0} exists.'.format(init_py))
+        break
+if not is_installed:
+    sys.exit('__init__.py does not exist.')
 '''
         cmd = '{0} -c "{1}"'.format(python_path, script)
         is_installed = _run_cmd(cmd)
@@ -219,6 +224,7 @@ if sys.version_info >= (3, 2):
         lib_dirs = site.getsitepackages()
 
 lib_dirs.append(get_python_lib())
+lib_dirs.append(get_python_lib(plat_specific=True))
 for lib_dir in lib_dirs:
     rpm_dir = os.path.join(lib_dir, 'rpm')
     if os.path.isdir(rpm_dir):


### PR DESCRIPTION
This fixes: https://github.com/junaruga/rpm-py-installer/issues/173 .

* Arch site-packages: `/usr/<lib64 or lib32>/pythonX.Y/site-packages`
* Non-arch site-packages: `/usr/lib/pythonX.Y/site-packages`

It was reported and proposed by John Vandenberg (@jayvdb).
Thanks!

