### PR TITLE
tox on Ubuntu trusty Python 3.4 case needs pathlib2 to run.

### DIFF
--- a/.travis/Dockerfile.ubuntu_trusty
+++ b/.travis/Dockerfile.ubuntu_trusty
@@ -14,6 +14,6 @@ RUN apt-get install -y \
   # -- RPM packages required for a specified case --
   git
 RUN apt-get clean all
-RUN python3 -m pip install tox
+RUN python3 -m pip install --upgrade -rtox-requirements.txt
 
 CMD ["/usr/local/bin/tox"]

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -7,3 +7,5 @@ virtualenv<16.0.0
 # Upstream changed to use "python -m pip", but Pytyon 2.6 does not support it.
 # https://github.com/tox-dev/tox/commit/e057755
 tox<3.2
+# tox on Ubuntu trusty Python 3.4 case needs pathlib2 to run.
+pathlib2


### PR DESCRIPTION
This PR fixes below error on only Ubuntu Trusty testing environment.

```
$ make build SERVICE=ubuntu_trusty

$ make test SERVICE=ubuntu_trusty
docker-compose run --rm ubuntu_trusty
Traceback (most recent call last):
  File "/usr/local/bin/tox", line 7, in <module>
    from tox import cmdline
  File "/usr/local/lib/python3.4/dist-packages/tox/__init__.py", line 9, in <module>
    import pluggy
  File "/usr/local/lib/python3.4/dist-packages/pluggy/__init__.py", line 16, in <module>
    from .manager import PluginManager, PluginValidationError
  File "/usr/local/lib/python3.4/dist-packages/pluggy/manager.py", line 6, in <module>
    import importlib_metadata
  File "/usr/local/lib/python3.4/dist-packages/importlib_metadata/__init__.py", line 14, in <module>
    from ._compat import (
  File "/usr/local/lib/python3.4/dist-packages/importlib_metadata/_compat.py", line 30, in <module>
    import pathlib2 as pathlib
ImportError: No module named 'pathlib2'
make: *** [Makefile:13: test] Error 1
```
