### PR TITLE
Add Fedora ARM 32 bit case on Shippable CI.

### DIFF
--- a/ci/Dockerfile-fedora
+++ b/ci/Dockerfile-fedora
@@ -9,10 +9,14 @@ COPY ci/entrypoint.sh .
 COPY tox-requirements.txt .
 COPY test-requirements.txt .
 
+RUN uname -a
+RUN rpm -q rpm
 RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.conf
-
-RUN dnf -y update
-RUN dnf -y --allowerasing install \
+# When kernel and user space architecture is different,
+# Need to use "--forcearch <user space arch>" option.
+RUN ARCH=$(rpm -q rpm --qf "%{arch}") \
+  && dnf -y --forcearch "${ARCH}" upgrade \
+  && dnf -y --forcearch "${ARCH}" install \
   # -- RPM packages required for installing --
   rpm-libs \
   redhat-rpm-config \

--- a/shippable.yml
+++ b/shippable.yml
@@ -3,6 +3,8 @@ matrix:
   include:
     - nodePool: shippable_shared_aarch64
       env: SERVICE="fedora30_aarch64" CONTAINER_IMAGE="multiarch/fedora:30-aarch64" TOXENV=py37
+    - nodePool: shippable_shared_aarch32
+      env: SERVICE="fedora28_arm32" CONTAINER_IMAGE="arm32v7/fedora:28" TOXENV=py36
 build:
   # Setting to add volume mounts.
   # https://github.com/Shippable/support/issues/4824#issuecomment-491332199

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,9 +55,12 @@ def install_script_path():
 
 
 @pytest.fixture
-def arch():
+def arch(is_fedora):
     """Return architecture."""
-    return cmd_stdout('uname -m')
+    os_arch = cmd_stdout('uname -m')
+    if is_fedora:
+        os_arch = cmd_stdout('rpm -q rpm --qf %{arch}')
+    return os_arch
 
 
 @pytest.fixture
@@ -131,8 +134,12 @@ def is_dnf():
 
 
 @pytest.fixture
-def pkg_cmd(is_dnf):
-    return 'dnf' if is_dnf else 'yum'
+def pkg_cmd(is_dnf, arch):
+    cmd = 'dnf' if is_dnf else 'yum'
+    cmd = '{0} -y'.format(cmd)
+    if is_dnf:
+        cmd = '{0} --forcearch {1}'.format(cmd, arch)
+    return cmd
 
 
 @pytest.fixture

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -431,11 +431,13 @@ def test_rpm_is_package_installed_returns_false(sys_rpm):
         assert not sys_rpm.is_package_installed('dummy')
 
 
-def test_rpm_lib_dir_is_ok(sys_rpm, is_debian):
+def test_rpm_lib_dir_is_ok(sys_rpm, is_debian, arch):
     if is_debian:
-        assert sys_rpm.lib_dir == '/usr/lib/x86_64-linux-gnu'
+        lib_dir = '/usr/lib/{0}-linux-gnu'.format(arch)
+        assert sys_rpm.lib_dir == lib_dir
     else:
-        assert sys_rpm.lib_dir == '/usr/lib64'
+        # 64-bit: /usr/lib64, 32-bit: /usr/lib
+        assert re.match('^/usr/lib(64)?$', sys_rpm.lib_dir)
 
 
 @pytest.mark.parametrize('value_dict', [

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -91,28 +91,22 @@ def test_install_and_uninstall_are_ok_on_sys_status(
         pytest.skip('install without setup.py.in should be downlodable.')
 
     if is_rpm_devel:
-        _run_cmd('{0} -y install rpm-devel'.format(pkg_cmd))
+        _run_cmd('{0} install rpm-devel'.format(pkg_cmd))
     else:
-        _run_cmd('{0} -y remove rpm-devel popt-devel'.format(pkg_cmd))
+        _run_cmd('{0} remove rpm-devel popt-devel'.format(pkg_cmd))
 
     if is_downloadable:
-        _install_rpm_download_utility(is_dnf)
+        _install_rpm_download_utility(is_dnf, pkg_cmd)
     else:
-        _uninstall_rpm_download_utility(is_dnf)
-
-    # if is_rpm_build_libs:
-    #     _run_cmd('{0} -y install rpm-build-libs'.format(pkg_cmd))
-    # else:
-    #     _run_cmd('{0} -y remove rpm-build-libs'.format(pkg_cmd))
+        _uninstall_rpm_download_utility(is_dnf, pkg_cmd)
 
     try:
         _assert_install_and_uninstall(install_script_path)
     finally:
         try:
             # Reset as default system status.
-            _run_cmd('{0} -y remove rpm-devel popt-devel'.format(pkg_cmd))
-            _install_rpm_download_utility(is_dnf)
-            # _run_cmd('{0} -y install rpm-build-libs'.format(pkg_cmd))
+            _run_cmd('{0} remove rpm-devel popt-devel'.format(pkg_cmd))
+            _install_rpm_download_utility(is_dnf, pkg_cmd)
         except Exception:
             pass
 
@@ -270,19 +264,19 @@ except AttributeError as e:
     return _run_cmd(cmd)
 
 
-def _install_rpm_download_utility(is_dnf):
+def _install_rpm_download_utility(is_dnf, pkg_cmd):
     if is_dnf:
-        _run_cmd("dnf -y install 'dnf-command(download)'")
+        _run_cmd("{0} install 'dnf-command(download)'".format(pkg_cmd))
     else:
         # Install yumdownloader
-        _run_cmd('yum -y install /usr/bin/yumdownloader')
+        _run_cmd('{0} install /usr/bin/yumdownloader'.format(pkg_cmd))
 
 
-def _uninstall_rpm_download_utility(is_dnf):
+def _uninstall_rpm_download_utility(is_dnf, pkg_cmd):
     if is_dnf:
-        _run_cmd('dnf -y remove dnf-plugins-core')
+        _run_cmd('{0} remove dnf-plugins-core'.format(pkg_cmd))
     else:
-        _run_cmd('yum -y remove /usr/bin/yumdownloader')
+        _run_cmd('{0} remove /usr/bin/yumdownloader'.format(pkg_cmd))
 
 
 def _run_cmd(cmd):


### PR DESCRIPTION
Current status:

ARM 32-bit case is failed for below reason in below CI result.
https://app.shippable.com/github/junaruga/rpm-py-installer/runs/25/2/console

Tasks and memo for this PR.

### dnf install to forcely override arch

`dnf install` does not work for some packages with below message.

```
Problem 1: conflicting requests
  - package cpio-2.12-7.fc28.armv7hl does not have a compatible architecture
 Problem 2: conflicting requests
  - package which-2.21-8.fc28.armv7hl does not have a compatible architecture
 Problem 3: conflicting requests
  - nothing provides /usr/bin/find needed by redhat-rpm-config-110-1.fc28.noarch
  - nothing provides zip needed by redhat-rpm-config-106-1.fc28.noarch
 Problem 4: conflicting requests
  - package python37-3.7.3-1.fc28.armv7hl does not have a compatible architecture
  - package python37-3.7.0-0.14.b3.fc28.armv7hl does not have a compatible architecture
 Problem 5: conflicting requests
  - package python35-3.5.7-1.fc28.armv7hl does not have a compatible architecture
  - package python35-3.5.4-2.fc28.armv7hl does not have a compatible architecture
 Problem 6: conflicting requests
  - package python3-devel-3.6.8-3.fc28.armv7hl does not have a compatible architecture
  - package python3-devel-3.6.5-1.fc28.armv7hl does not have a compatible architecture
 Problem 7: conflicting requests
  - package python26-2.6.9-17.fc28.armv7hl does not have a compatible architecture
  - package python26-2.6.9-14.fc28.armv7hl does not have a compatible architecture
 Problem 8: conflicting requests
  - package python2-2.7.15-4.fc28.armv7hl does not have a compatible architecture
  - package python2-2.7.14-15.fc28.armv7hl does not have a compatible architecture
 Problem 9: conflicting requests
  - package git-core-2.17.2-2.fc28.armv7hl does not have a compatible architecture
  - package git-core-2.17.0-1.fc28.armv7hl does not have a compatible architecture
 Problem 10: conflicting requests
  - package gcc-8.3.1-2.fc28.armv7hl does not have a compatible architecture
  - package gcc-8.0.1-0.20.fc28.armv7hl does not have a compatible architecture
```
As a solution, if `HACK_ARM32` environment, run `dnf install --forcearch $ARCH`.
See https://bugzilla.redhat.com/show_bug.cgi?id=1529028


### A real failure on 32-bit case.

Fix just below cases.
For there is also Debian case issue in the test, when adding Ubuntu ARM-32 bit case, fix it.

```
    def test_rpm_lib_dir_is_ok(sys_rpm, is_debian):
        if is_debian:
            assert sys_rpm.lib_dir == '/usr/lib/x86_64-linux-gnu'
        else:
>           assert sys_rpm.lib_dir == '/usr/lib64'
E           AssertionError: assert '/usr/lib' == '/usr/lib64'
E             - /usr/lib
E             + /usr/lib64
E             ?         ++

tests/test_install.py:438: AssertionError
```

### A actual latest available Fedora ARM 32-bit is Fedora 28.

For Fedora 29, 30, actually the composing is failed on Fedora project.

