### PR TITLE
Remove TOXENV adding LINT=false.

### DIFF
--- a/ci/Dockerfile-fedora
+++ b/ci/Dockerfile-fedora
@@ -1,7 +1,7 @@
 ARG CONTAINER_IMAGE=fedora:latest
 FROM ${CONTAINER_IMAGE}
 
-ARG TOXENV
+ARG LINT=false
 
 WORKDIR /build
 COPY ci/dnf_install_lint_pkgs.sh .


### PR DESCRIPTION
TOXENV is not used in the container building time any more.
LINT is used instead of that in ci/dnf_install_lint_pkgs.sh.