### PR TITLE
Add pyXX-cov cases to tox.ini.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         CONTAINER_IMAGE: fedora:30
         LINT: "true"
     environment:
-      TOXENV: ${TOXENV-lint-py3,lint-py2,py37,py27}
+      TOXENV: ${TOXENV-lint-py3,lint-py2,py37-cov,py27-cov}
     command: tox
   fedora30_aarch64:
     container_name: fedora30_aarch64
@@ -89,7 +89,7 @@ services:
       context: .
       dockerfile: ci/Dockerfile-centos.7
     environment:
-      TOXENV: ${TOXENV-py36,py34,py27}
+      TOXENV: ${TOXENV-py36-cov,py34-cov,py27-cov}
     command: tox
   centos6:
     container_name: centos6
@@ -106,7 +106,7 @@ services:
       context: .
       dockerfile: ci/Dockerfile-ubuntu.bionic
     environment:
-      TOXENV: ${TOXENV-py36,py27}
+      TOXENV: ${TOXENV-py36-cov,py27-cov}
     command: tox
   ubuntu_trusty:
     container_name: ubuntu_trusy

--- a/install.py
+++ b/install.py
@@ -1770,7 +1770,10 @@ class Cmd(object):
 
         env = os.environ.copy()
         # Better to parse English output
-        env['LC_ALL'] = 'en_US.utf-8'
+        # * LC_ALL=C.UTF-8 shows a warning
+        #   "cannot change locale (*) No such file or directory" on CentOS7.
+        # * LC_ALL=en_US.UTF-8 shows the warning on Fedora 30.
+        env['LC_ALL'] = ''
         if 'env' in kwargs:
             env.update(kwargs['env'])
         cmd_kwargs['env'] = env

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint-py3,lint-py2,py37,py36,py35,py34,py27,py26
+envlist = lint-py{3,2},py{37,36,35,34,27,26}{-cov,}
 # Do not run actual install process in tox.
 skipsdist = True
 
@@ -17,10 +17,10 @@ commands =
     rpm --version
     pytest \
         -m unit \
-        --cov-config .coveragerc \
-        --cov . \
-        --cov-report term \
-        --cov-report html \
+    cov:    --cov-config .coveragerc \
+    cov:    --cov . \
+    cov:    --cov-report term \
+    cov:    --cov-report html \
         {posargs}
 
 [testenv:py26]


### PR DESCRIPTION
Because I do not want to run coverage program that causes an error on some platforms. That also saves the running time.
Now the tox tasks are like this.

```
$ tox -l
lint-py3
lint-py2
py37-cov
py37
py36-cov
py36
py35-cov
py35
py34-cov
py34
py27-cov
py27
py26-cov
py26
```
