### PR TITLE
Refactoring: Move all Fedora specific tests into test_install_fedora.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,8 @@ def _get_os_id():
 _os_id = _get_os_id()
 _is_dnf = True if os.system('dnf --version') == 0 else False
 _is_debian = True if _os_id in ['debian', 'ubuntu'] else False
+_is_fedora = _os_id == 'fedora'
+_is_centos = _os_id == 'centos'
 
 
 def pytest_collection_modifyitems(items):
@@ -78,13 +80,13 @@ def arch(is_fedora):
 @pytest.fixture
 def is_fedora():
     """Return if it is Fedora Linux."""
-    return _os_id == 'fedora'
+    return _is_fedora
 
 
 @pytest.fixture
 def is_centos():
     """Return if it is CentOS Linux."""
-    return _os_id == 'centos'
+    return _is_centos
 
 
 @pytest.fixture
@@ -212,6 +214,12 @@ def helper_is_debian():
     """Return if it is Debian base Linux. """
     # TODO: This method is duplicated with fixture: is_debian.
     return _is_debian
+
+
+@pytest.helpers.register
+def helper_is_fedora_based():
+    """Returns whether this is a Fedora/RHEL based Linux. """
+    return _is_fedora or _is_centos
 
 
 @pytest.helpers.register

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from install import (Application,
                      SetupPy)
 
 OS_RELEASE_FILE = '/etc/os-release'
+REDHAT_RELEASE_FILE = '/etc/redhat-release'
 
 install_path = os.path.abspath('install.py')
 sys.path.insert(0, install_path)
@@ -52,7 +53,11 @@ _os_id = _get_os_id()
 _is_dnf = True if os.system('dnf --version') == 0 else False
 _is_debian = True if _os_id in ['debian', 'ubuntu'] else False
 _is_fedora = _os_id == 'fedora'
-_is_centos = _os_id == 'centos'
+# CentOS6 does not have /etc/os-release file. only has /etc/redhat-release.
+# When the /etc/redhat-release exists, identify it as centos
+# to run fedora base specific tests in test_install_fedora.py.
+_is_centos = _os_id == 'centos' or \
+  (not _os_id and os.path.isfile(REDHAT_RELEASE_FILE))
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4,16 +4,13 @@ Tests for install.py
 """
 import os
 import re
-import shutil
 import sys
 import tempfile
 from unittest import mock
 
 import pytest
 from install import (Cmd,
-                     CmdError,
                      Downloader,
-                     FedoraRpm,
                      InstallError,
                      InstallSkipError,
                      Linux,
@@ -275,19 +272,6 @@ def test_python_is_python_binding_installed_on_pip_less_than_9(rpm_py_name):
         assert python.is_python_binding_installed_on_pip() is installed
 
 
-@pytest.mark.parametrize('is_dnf', [True, False])
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_rpm_init_is_ok(is_dnf, sys_rpm_path, arch):
-    with mock.patch.object(Cmd, 'which') as mock_which:
-        mock_which.return_value = is_dnf
-        rpm = FedoraRpm(sys_rpm_path)
-        assert mock_which.called
-        assert rpm.rpm_path == sys_rpm_path
-        assert rpm.is_dnf is is_dnf
-        assert rpm.arch == arch
-
-
 def test_rpm_init_raises_error_on_not_existed_rpm(is_debian):
     with pytest.raises(InstallError) as ei:
         get_rpm(is_debian, '/usr/bin/rpm123')
@@ -319,25 +303,6 @@ def test_rpm_is_system_rpm_returns_false(local_rpm):
     assert rpm.is_system_rpm() is False
 
 
-@pytest.mark.parametrize('version_info,has_rpm_bulid_libs', [
-    ((4, 8, 1),          False),
-    ((4, 9, 0, 'beta1'), True),
-    ((4, 9, 0, 'rc1'),   True),
-    ((4, 9, 0),          True),
-    ((4, 10, 0),         True),
-])
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_rpm_has_composed_rpm_bulid_libs_is_ok(
-    local_rpm, version_info, has_rpm_bulid_libs, monkeypatch
-):
-    rpm = local_rpm
-    monkeypatch.setattr(type(rpm), 'version_info',
-                        mock.PropertyMock(return_value=version_info))
-    has_build_libs = rpm.has_composed_rpm_bulid_libs()
-    assert has_build_libs == has_rpm_bulid_libs
-
-
 @pytest.mark.parametrize('package_name', ['rpm-lib'])
 def test_rpm_is_package_installed_returns_true(sys_rpm, package_name):
     assert not sys_rpm.is_package_installed(package_name)
@@ -356,83 +321,6 @@ def test_rpm_lib_dir_is_ok(sys_rpm, is_debian, arch):
     else:
         # 64-bit: /usr/lib64, 32-bit: /usr/lib
         assert re.match(r'^/usr/lib(64)?$', sys_rpm.lib_dir)
-
-
-@pytest.mark.parametrize('value_dict', [
-    {
-        'is_dnf': True,
-        'cmd': 'dnf',
-    },
-    {
-        'is_dnf': False,
-        'cmd': 'yum',
-    },
-])
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_rpm_package_cmd_is_ok(sys_rpm, value_dict):
-    sys_rpm.is_dnf = value_dict['is_dnf']
-    assert sys_rpm.package_cmd == value_dict['cmd']
-
-
-@pytest.mark.parametrize('is_dnf', [True, False])
-@pytest.mark.parametrize('installed', [True, False])
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_rpm_is_downloadable_is_ok(sys_rpm, is_dnf, installed):
-    sys_rpm.is_dnf = is_dnf
-    sys_rpm.is_package_installed = mock.MagicMock(return_value=installed)
-    assert sys_rpm.is_downloadable() is installed
-
-
-@pytest.mark.parametrize('is_dnf', [True, False])
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_rpm_download_is_ok(sys_rpm, is_dnf):
-    sys_rpm.is_dnf = is_dnf
-    with pytest.helpers.work_dir():
-        with mock.patch.object(Cmd, 'sh_e') as mock_sh_e:
-            sys_rpm.download('dummy')
-            assert mock_sh_e.called
-
-
-@pytest.mark.parametrize('is_dnf,stdout,stderr', [
-    (True, '', 'foo\nNo package dummy.x86_64 available.\nbar\n'),
-    (False, 'foo\nNo Match for argument dummy.x86_64\nbar\n', ''),
-])
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_rpm_download_raise_not_found_error(sys_rpm, is_dnf, stdout, stderr):
-    sys_rpm.is_dnf = is_dnf
-    with mock.patch.object(Cmd, 'sh_e') as mock_sh_e:
-        ce = CmdError('test.')
-        ce.stdout = stdout
-        ce.stderr = stderr
-        mock_sh_e.side_effect = ce
-        with pytest.raises(RemoteFileNotFoundError) as e:
-            sys_rpm.download('dummy')
-        assert mock_sh_e.called
-        assert 'Package dummy not found on remote' == str(e.value)
-
-
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_rpm_extract_is_ok(sys_rpm, rpm_files, monkeypatch):
-    # mocking arch object for multi arch test cases.
-    sys_rpm.arch = 'x86_64'
-    with pytest.helpers.work_dir():
-        for rpm_file in rpm_files:
-            shutil.copy(rpm_file, '.')
-
-        sys_rpm.extract('rpm-build-libs')
-        files = os.listdir('./usr/lib64')
-        files.sort()
-        assert files == [
-            'librpmbuild.so.7',
-            'librpmbuild.so.7.0.1',
-            'librpmsign.so.7',
-            'librpmsign.so.7.0.1',
-        ]
 
 
 @pytest.mark.parametrize('version,info,is_release,git_branch', [
@@ -797,127 +685,6 @@ def test_installer_init_is_ok(installer):
     assert installer.setup_py_opts == '-q'
 
 
-@pytest.mark.parametrize(
-    'rpm_version_info,package_names_py3,package_names_py2',
-    [
-        (
-            (4, 14, 0),
-            ['python3-rpm'],
-            ['python2-rpm'],
-        ),
-        (
-            (4, 13, 0),
-            ['python3-rpm', 'rpm-python3'],
-            ['python2-rpm', 'rpm-python'],
-        ),
-        (
-            (4, 12, 0),
-            ['rpm-python3'],
-            ['rpm-python'],
-        ),
-        (
-            (4, 11, 1),
-            ['rpm-python3'],
-            ['rpm-python'],
-        ),
-        (
-            (4, 11, 0),
-            [],
-            ['rpm-python'],
-        ),
-    ]
-)
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_installer_predict_rpm_py_package_names(
-    installer, rpm_version_info, package_names_py3, package_names_py2,
-    monkeypatch
-):
-    monkeypatch.setattr(type(installer.rpm), 'version_info',
-                        mock.PropertyMock(return_value=rpm_version_info))
-    expected_package_names = None
-    if sys.version_info >= (3, 0):
-        expected_package_names = package_names_py3
-    else:
-        expected_package_names = package_names_py2
-
-    if expected_package_names:
-        dst_package_names = installer._predict_rpm_py_package_names()
-        assert dst_package_names == expected_package_names
-    else:
-        with pytest.raises(InstallError) as ie:
-            installer._predict_rpm_py_package_names()
-            assert 'No predicted package' in str(ie.value)
-
-
-@pytest.mark.parametrize('statuses', [
-    [
-        {'name': 'python3-rpm', 'side_effect': None},
-    ],
-    [
-        {'name': 'rpm-python3', 'side_effect': None},
-        {'name': 'rpm-python', 'side_effect': None},
-    ],
-    [
-        {'name': 'rpm-python3', 'side_effect': RemoteFileNotFoundError},
-        {'name': 'rpm-python', 'side_effect': None},
-    ],
-    [],
-])
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_installer_download_and_extract_rpm_py_package(installer, statuses):
-    package_names = list(map(lambda status: status['name'], statuses))
-    side_effects = list(map(lambda status: status['side_effect'], statuses))
-    installer._predict_rpm_py_package_names = mock.Mock(
-            return_value=package_names)
-    installer.rpm.download_and_extract = mock.Mock(
-        # Describe each side_effect called one by one.
-        side_effect=side_effects
-    )
-
-    if statuses and side_effects[-1] is None:
-        installer._download_and_extract_rpm_py_package()
-        assert installer.rpm.download_and_extract.called
-    else:
-        with pytest.raises(RpmPyPackageNotFoundError):
-            installer._download_and_extract_rpm_py_package()
-
-
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_fedora_installer_install_from_rpm_py_package(installer, monkeypatch):
-    dst_rpm_dir = 'dummy/dst/lib64/pythonX.Y/site-packages/rpm'
-    rpm_dirs = [
-        dst_rpm_dir,
-        'dummy/dst/lib/pythonX.Y/site-packages/rpm'
-    ]
-
-    def download_and_extract_side_effect(*args):
-        py_dir_name = 'python{0}.{1}'.format(
-                      sys.version_info[0], sys.version_info[1])
-        downloaded_rpm_dir = 'usr/lib64/{0}/site-packages/rpm'.format(
-            py_dir_name
-        )
-        os.makedirs(downloaded_rpm_dir)
-        pytest.helpers.touch(os.path.join(downloaded_rpm_dir, '__init__.py'))
-
-    installer._download_and_extract_rpm_py_package = mock.Mock(
-            side_effect=download_and_extract_side_effect)
-    monkeypatch.setattr(type(installer.python), 'python_lib_rpm_dirs',
-                        mock.PropertyMock(return_value=rpm_dirs))
-    monkeypatch.setattr(type(installer.python), 'python_lib_rpm_dir',
-                        mock.PropertyMock(return_value=dst_rpm_dir))
-
-    with pytest.helpers.work_dir():
-        assert not os.path.isfile(os.path.join(dst_rpm_dir, '__init__.py'))
-
-        installer.install_from_rpm_py_package()
-
-        assert os.path.isdir(dst_rpm_dir)
-        assert os.path.isfile(os.path.join(dst_rpm_dir, '__init__.py'))
-
-
 @pytest.mark.network
 def test_installer_install_from_rpm_py_package(
     installer, is_debian, is_centos, monkeypatch
@@ -965,34 +732,6 @@ def test_installer_make_dep_lib_file_links_and_copy_include_files(installer):
 Install a {0} download plugin or
 install the {0} package [{1}].
 '''.format(installer.package_sys_name, installer.package_popt_devel_name)
-    assert expected_message == str(ei.value)
-
-
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_installer_run_raises_error_for_rpm_build_libs(installer):
-    installer.rpm.has_composed_rpm_bulid_libs = mock.MagicMock(
-        return_value=True
-    )
-    installer._is_rpm_all_lib_include_files_installed = mock.MagicMock(
-        return_value=False
-    )
-    installer.rpm.is_downloadable = mock.MagicMock(
-        return_value=False
-    )
-    installer._is_rpm_build_libs_installed = mock.MagicMock(
-        return_value=False
-    )
-
-    with pytest.raises(InstallError) as ei:
-        installer.run()
-    expected_message = '''
-Install failed without rpm-devel package by below reason.
-Can you install the RPM package, and run this installer again?
-
-Required RPM not installed: [rpm-build-libs],
-when a RPM download plugin not installed.
-'''
     assert expected_message == str(ei.value)
 
 
@@ -1147,21 +886,6 @@ or set a environment variable RPM_PY_SYS=true
 
 
 @pytest.mark.network
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_app_verify_system_status_is_error_on_sys_rpm_and_missing_pkgs(app):
-    app.linux.rpm.is_system_rpm = mock.MagicMock(return_value=True)
-    app.linux.rpm.is_package_installed = mock.MagicMock(return_value=False)
-    with pytest.raises(InstallError) as ei:
-        app.linux.verify_system_status()
-    expected_message = '''
-Required RPM not installed: [rpm-libs].
-Install the RPM package.
-'''
-    assert expected_message == str(ei.value)
-
-
-@pytest.mark.network
 @pytest.mark.parametrize('rpm_py_version',
                          ['4.13.0', '4.14.0-rc1'])
 @mock.patch.object(Log, 'verbose', new=False)
@@ -1189,56 +913,3 @@ def test_app_run_is_ok_on_download_by_rpm_py_version(app, rpm_py_version):
     with pytest.helpers.work_dir():
         app.run()
     assert True
-
-
-@pytest.mark.network
-@pytest.mark.parametrize(
-    'is_rpm_devel, is_popt_devel, is_downloadable, is_rpm_build_libs', [
-        (True,  True, False, False),
-        (False, False, True, True),
-        (False, False, True, False),
-    ], ids=[
-        'rpm-devel and popt-devel installed',
-        'rpm-devel, popt-devel not installed, RPM downloadable',
-        'rpm-devel, popt-devel, rpm-build-libs not installed, '
-        'RPM downloadable',
-    ]
-)
-@mock.patch.object(Log, 'verbose', new=False)
-@pytest.mark.skipif(pytest.helpers.helper_is_debian(),
-                    reason='Only Linux Fedora.')
-def test_app_run_is_ok(
-    app, is_rpm_devel, is_popt_devel, is_downloadable, is_rpm_build_libs,
-    rpm_version_info_min_setup_py_in
-):
-    app.is_work_dir_removed = True
-    app.rpm_py.installer._is_rpm_all_lib_include_files_installed = \
-        mock.MagicMock(
-            return_value=is_rpm_devel
-        )
-    app.rpm_py.installer._is_popt_devel_installed = mock.MagicMock(
-        return_value=is_popt_devel
-    )
-    app.rpm_py.installer.rpm.is_downloadable = mock.MagicMock(
-        return_value=is_downloadable
-    )
-    app.rpm_py.installer._is_rpm_build_libs_installed = mock.MagicMock(
-        return_value=is_rpm_build_libs
-    )
-    if is_rpm_devel:
-        app.rpm_py.installer._build_and_install = mock.MagicMock()
-        app.python.is_python_binding_installed = mock.MagicMock(
-            return_value=True
-        )
-
-    app.run()
-
-    # If setup.py.in does not exist in old RPM, skip below checks.
-    if app.linux.rpm.version_info < rpm_version_info_min_setup_py_in:
-        return
-
-    assert app.rpm_py.installer._is_rpm_all_lib_include_files_installed.called
-    if not is_rpm_devel:
-        assert app.rpm_py.installer.rpm.is_downloadable.called
-        if is_downloadable:
-            assert app.rpm_py.installer._is_rpm_build_libs_installed.called

--- a/tests/test_install_fedora.py
+++ b/tests/test_install_fedora.py
@@ -1,0 +1,321 @@
+"""
+Tests for install.py for Fedora based Linux distributions
+
+"""
+import os
+import shutil
+import sys
+from unittest import mock
+
+import pytest
+from install import (Cmd,
+                     CmdError,
+                     FedoraRpm,
+                     InstallError,
+                     Log,
+                     RemoteFileNotFoundError,
+                     RpmPyPackageNotFoundError)
+
+pytestmark = pytest.mark.skipif(
+    not pytest.helpers.helper_is_fedora_based(),
+    reason="Tests for Fedora based Linux"
+)
+
+
+@pytest.mark.parametrize('is_dnf', [True, False])
+def test_rpm_init_is_ok(is_dnf, sys_rpm_path, arch):
+    with mock.patch.object(Cmd, 'which') as mock_which:
+        mock_which.return_value = is_dnf
+        rpm = FedoraRpm(sys_rpm_path)
+        assert mock_which.called
+        assert rpm.rpm_path == sys_rpm_path
+        assert rpm.is_dnf is is_dnf
+        assert rpm.arch == arch
+
+
+@pytest.mark.parametrize('version_info,has_rpm_bulid_libs', [
+    ((4, 8, 1),          False),
+    ((4, 9, 0, 'beta1'), True),
+    ((4, 9, 0, 'rc1'),   True),
+    ((4, 9, 0),          True),
+    ((4, 10, 0),         True),
+])
+def test_rpm_has_composed_rpm_bulid_libs_is_ok(
+    local_rpm, version_info, has_rpm_bulid_libs, monkeypatch
+):
+    rpm = local_rpm
+    monkeypatch.setattr(type(rpm), 'version_info',
+                        mock.PropertyMock(return_value=version_info))
+    assert rpm.has_composed_rpm_bulid_libs() == has_rpm_bulid_libs
+
+
+@pytest.mark.parametrize('value_dict', [
+    {
+        'is_dnf': True,
+        'cmd': 'dnf',
+    },
+    {
+        'is_dnf': False,
+        'cmd': 'yum',
+    },
+])
+def test_rpm_package_cmd_is_ok(sys_rpm, value_dict):
+    sys_rpm.is_dnf = value_dict['is_dnf']
+    assert sys_rpm.package_cmd == value_dict['cmd']
+
+
+@pytest.mark.parametrize('is_dnf', [True, False])
+@pytest.mark.parametrize('installed', [True, False])
+def test_rpm_is_downloadable_is_ok(sys_rpm, is_dnf, installed):
+    sys_rpm.is_dnf = is_dnf
+    sys_rpm.is_package_installed = mock.MagicMock(return_value=installed)
+    assert sys_rpm.is_downloadable() is installed
+
+
+@pytest.mark.parametrize('is_dnf', [True, False])
+def test_rpm_download_is_ok(sys_rpm, is_dnf):
+    sys_rpm.is_dnf = is_dnf
+    with pytest.helpers.work_dir():
+        with mock.patch.object(Cmd, 'sh_e') as mock_sh_e:
+            sys_rpm.download('dummy')
+            assert mock_sh_e.called
+
+
+@pytest.mark.parametrize('is_dnf,stdout,stderr', [
+    (True, '', 'foo\nNo package dummy.x86_64 available.\nbar\n'),
+    (False, 'foo\nNo Match for argument dummy.x86_64\nbar\n', ''),
+])
+def test_rpm_download_raise_not_found_error(sys_rpm, is_dnf, stdout, stderr):
+    sys_rpm.is_dnf = is_dnf
+    with mock.patch.object(Cmd, 'sh_e') as mock_sh_e:
+        ce = CmdError('test.')
+        ce.stdout = stdout
+        ce.stderr = stderr
+        mock_sh_e.side_effect = ce
+        with pytest.raises(RemoteFileNotFoundError) as e:
+            sys_rpm.download('dummy')
+        assert mock_sh_e.called
+        assert 'Package dummy not found on remote' == str(e.value)
+
+
+def test_rpm_extract_is_ok(sys_rpm, rpm_files, monkeypatch):
+    # mocking arch object for multi arch test cases.
+    sys_rpm.arch = 'x86_64'
+    with pytest.helpers.work_dir():
+        for rpm_file in rpm_files:
+            shutil.copy(rpm_file, '.')
+
+        sys_rpm.extract('rpm-build-libs')
+        files = os.listdir('./usr/lib64')
+        files.sort()
+        assert files == [
+            'librpmbuild.so.7',
+            'librpmbuild.so.7.0.1',
+            'librpmsign.so.7',
+            'librpmsign.so.7.0.1',
+        ]
+
+
+@pytest.mark.parametrize(
+    'rpm_version_info,package_names_py3,package_names_py2',
+    [
+        (
+            (4, 14, 0),
+            ['python3-rpm'],
+            ['python2-rpm'],
+        ),
+        (
+            (4, 13, 0),
+            ['python3-rpm', 'rpm-python3'],
+            ['python2-rpm', 'rpm-python'],
+        ),
+        (
+            (4, 12, 0),
+            ['rpm-python3'],
+            ['rpm-python'],
+        ),
+        (
+            (4, 11, 1),
+            ['rpm-python3'],
+            ['rpm-python'],
+        ),
+        (
+            (4, 11, 0),
+            [],
+            ['rpm-python'],
+        ),
+    ]
+)
+def test_installer_predict_rpm_py_package_names(
+    installer, rpm_version_info, package_names_py3, package_names_py2,
+    monkeypatch
+):
+    monkeypatch.setattr(type(installer.rpm), 'version_info',
+                        mock.PropertyMock(return_value=rpm_version_info))
+    expected_package_names = None
+    if sys.version_info >= (3, 0):
+        expected_package_names = package_names_py3
+    else:
+        expected_package_names = package_names_py2
+
+    if expected_package_names:
+        dst_package_names = installer._predict_rpm_py_package_names()
+        assert dst_package_names == expected_package_names
+    else:
+        with pytest.raises(InstallError) as ie:
+            installer._predict_rpm_py_package_names()
+            assert 'No predicted pacakge' in str(ie.value)
+
+
+@pytest.mark.parametrize('statuses', [
+    [
+        {'name': 'python3-rpm', 'side_effect': None},
+    ],
+    [
+        {'name': 'rpm-python3', 'side_effect': None},
+        {'name': 'rpm-python', 'side_effect': None},
+    ],
+    [
+        {'name': 'rpm-python3', 'side_effect': RemoteFileNotFoundError},
+        {'name': 'rpm-python', 'side_effect': None},
+    ],
+    [],
+])
+def test_installer_download_and_extract_rpm_py_package(installer, statuses):
+    package_names = list(map(lambda status: status['name'], statuses))
+    side_effects = list(map(lambda status: status['side_effect'], statuses))
+    installer._predict_rpm_py_package_names = mock.Mock(
+            return_value=package_names)
+    installer.rpm.download_and_extract = mock.Mock(
+        # Describe each side_effect called one by one.
+        side_effect=side_effects
+    )
+
+    if statuses and side_effects[-1] is None:
+        installer._download_and_extract_rpm_py_package()
+        assert installer.rpm.download_and_extract.called
+    else:
+        with pytest.raises(RpmPyPackageNotFoundError):
+            installer._download_and_extract_rpm_py_package()
+
+
+def test_fedora_installer_install_from_rpm_py_package(installer, monkeypatch):
+    dst_rpm_dir = 'dummy/dst/lib64/pythonX.Y/site-packages/rpm'
+    rpm_dirs = [
+        dst_rpm_dir,
+        'dummy/dst/lib/pythonX.Y/site-packages/rpm'
+    ]
+
+    def download_and_extract_side_effect(*args):
+        py_dir_name = 'python{0}.{1}'.format(
+                      sys.version_info[0], sys.version_info[1])
+        downloaded_rpm_dir = 'usr/lib64/{0}/site-packages/rpm'.format(
+            py_dir_name
+        )
+        os.makedirs(downloaded_rpm_dir)
+        pytest.helpers.touch(os.path.join(downloaded_rpm_dir, '__init__.py'))
+
+    installer._download_and_extract_rpm_py_package = mock.Mock(
+            side_effect=download_and_extract_side_effect)
+    monkeypatch.setattr(type(installer.python), 'python_lib_rpm_dirs',
+                        mock.PropertyMock(return_value=rpm_dirs))
+    monkeypatch.setattr(type(installer.python), 'python_lib_rpm_dir',
+                        mock.PropertyMock(return_value=dst_rpm_dir))
+
+    with pytest.helpers.work_dir():
+        assert not os.path.isfile(os.path.join(dst_rpm_dir, '__init__.py'))
+
+        installer.install_from_rpm_py_package()
+
+        assert os.path.isdir(dst_rpm_dir)
+        assert os.path.isfile(os.path.join(dst_rpm_dir, '__init__.py'))
+
+
+def test_installer_run_raises_error_for_rpm_build_libs(installer):
+    installer.rpm.has_composed_rpm_bulid_libs = mock.MagicMock(
+        return_value=True
+    )
+    installer._is_rpm_all_lib_include_files_installed = mock.MagicMock(
+        return_value=False
+    )
+    installer.rpm.is_downloadable = mock.MagicMock(
+        return_value=False
+    )
+    installer._is_rpm_build_libs_installed = mock.MagicMock(
+        return_value=False
+    )
+
+    with pytest.raises(InstallError) as ei:
+        installer.run()
+    expected_message = '''
+Install failed without rpm-devel package by below reason.
+Can you install the RPM package, and run this installer again?
+
+Required RPM not installed: [rpm-build-libs],
+when a RPM download plugin not installed.
+'''
+    assert expected_message == str(ei.value)
+
+
+@pytest.mark.network
+def test_app_verify_system_status_is_error_on_sys_rpm_and_missing_pkgs(app):
+    app.linux.rpm.is_system_rpm = mock.MagicMock(return_value=True)
+    app.linux.rpm.is_package_installed = mock.MagicMock(return_value=False)
+    with pytest.raises(InstallError) as ei:
+        app.linux.verify_system_status()
+    expected_message = '''
+Required RPM not installed: [rpm-libs].
+Install the RPM package.
+'''
+    assert expected_message == str(ei.value)
+
+
+@pytest.mark.network
+@pytest.mark.parametrize(
+    'is_rpm_devel, is_popt_devel, is_downloadable, is_rpm_build_libs', [
+        (True,  True, False, False),
+        (False, False, True, True),
+        (False, False, True, False),
+    ], ids=[
+        'rpm-devel and popt-devel installed',
+        'rpm-devel, popt-devel not installed, RPM downloadable',
+        'rpm-devel, popt-devel, rpm-build-libs not installed, '
+        'RPM downloadable',
+    ]
+)
+@mock.patch.object(Log, 'verbose', new=False)
+def test_app_run_is_ok(
+    app, is_rpm_devel, is_popt_devel, is_downloadable, is_rpm_build_libs,
+    rpm_version_info_min_setup_py_in
+):
+    app.is_work_dir_removed = True
+    app.rpm_py.installer._is_rpm_all_lib_include_files_installed = \
+        mock.MagicMock(
+            return_value=is_rpm_devel
+        )
+    app.rpm_py.installer._is_popt_devel_installed = mock.MagicMock(
+        return_value=is_popt_devel
+    )
+    app.rpm_py.installer.rpm.is_downloadable = mock.MagicMock(
+        return_value=is_downloadable
+    )
+    app.rpm_py.installer._is_rpm_build_libs_installed = mock.MagicMock(
+        return_value=is_rpm_build_libs
+    )
+    if is_rpm_devel:
+        app.rpm_py.installer._build_and_install = mock.MagicMock()
+        app.python.is_python_binding_installed = mock.MagicMock(
+            return_value=True
+        )
+
+    app.run()
+
+    # If setup.py.in does not exist in old RPM, skip below checks.
+    if app.linux.rpm.version_info < rpm_version_info_min_setup_py_in:
+        return
+
+    assert app.rpm_py.installer._is_rpm_all_lib_include_files_installed.called
+    if not is_rpm_devel:
+        assert app.rpm_py.installer.rpm.is_downloadable.called
+        if is_downloadable:
+            assert app.rpm_py.installer._is_rpm_build_libs_installed.called


### PR DESCRIPTION
Adding helpers and fixtures to detect Fedora based

This is to cherry-pick a commit from https://github.com/junaruga/rpm-py-installer/pull/207 .

Thanks @dcermak 

[a] Current master branch: https://travis-ci.org/junaruga/rpm-py-installer/builds/579532829
[b] This PR's travis: https://travis-ci.org/junaruga/rpm-py-installer/builds/579539128

* fedora30
  * [a]
    * py37-cov: 127 passed, 2 deselected in 137.35 seconds
    * py27-cov: 127 passed, 2 deselected, 1 warnings in 96.03 seconds
  * [b]
    * py37-cov: 127 passed, 2 deselected in 130.71 seconds
    * py27-cov: 127 passed, 2 deselected, 1 warnings in 92.22 seconds
* fedora26
  * [a]
    * py35: 125 passed, 2 skipped, 2 deselected in 99.20 seconds
    * py26: 126 passed, 1 skipped, 2 deselected in 78.64 seconds
  * [b]
    * py35: 125 passed, 2 skipped, 2 deselected in 97.44 seconds
    * py26: 126 passed, 1 skipped, 2 deselected in 76.53 seconds
* intg
  * [a]: 2 passed, 127 deselected in 4.04 seconds
  * [b]: 2 passed, 127 deselected in 4.26 seconds
* centos7
  * [a]
    * py36-cov: 127 passed, 2 deselected in 75.45 seconds
    * py34-cov: 126 passed, 1 skipped, 2 deselected in 58.48 seconds
    * py27-cov: 127 passed, 2 deselected, 1 warnings in 60.51 seconds
  * [b]
    * py36-cov: 127 passed, 2 deselected in 79.27 seconds
    * py34-cov: 126 passed, 1 skipped, 2 deselected in 62.22 seconds
    * py27-cov: 127 passed, 2 deselected, 1 warnings in 66.18 seconds
* centos6
  * [a]
    * py27: 126 passed, 1 skipped, 2 deselected, 1 warnings in 47.74 seconds
    * py26: 126 passed, 1 skipped, 2 deselected in 43.64 seconds
  * [b]
    * py27: 93 passed, 34 skipped, 2 deselected, 1 warnings in 38.29 seconds
    * py26: 93 passed, 34 skipped, 2 deselected in 35.18 seconds
* ubuntu_bionic
  * [a]
    * py36-cov: 90 passed, 37 skipped, 2 deselected in 28.25 seconds
    * py27-cov: 90 passed, 37 skipped, 2 deselected, 1 warnings in 25.49 seconds
  * [b]
    * py36-cov: 90 passed, 37 skipped, 2 deselected in 29.56 seconds
    * py27-cov: 90 passed, 37 skipped, 2 deselected, 1 warnings in 27.15 seconds
* ubuntu_trusty
  * [a]
    * py34: 89 passed, 38 skipped, 2 deselected in 15.82 seconds
    * py27: 90 passed, 37 skipped, 2 deselected, 1 warnings in 24.02 seconds
  * [b]
    * py34: 89 passed, 38 skipped, 2 deselected in 15.35 seconds
    * py27: 90 passed, 37 skipped, 2 deselected, 1 warnings in 23.07 seconds

centos6: number of passed tests is changed from 126 to 93, why?