### PR TITLE
[WIP] Use podman and podman-compose on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,37 @@
 dist: xenial
 language: bash
-services: docker
 git:
   quiet: true
 env:
   global:
     - TARGETS=""
+    - DOCKER=podman
+
+# Definitions using YAML's anchor (&) and reference (*).
+.com.github.junaruga.rpm-py-installer.definitions:
+  - &podman
+    language: python
+    python: 3.6
+    addons:
+      apt:
+        update: true
+        sources:
+          - sourceline: "ppa:projectatomic/ppa"
+        packages:
+          - podman
+    before_install:
+      # Create /etc/containers/registries.conf, as podman does not install it.
+      # https://github.com/containers/libpod/issues/3679
+      - sudo mkdir -p /etc/containers
+      - echo -e "[registries.search]\nregistries = ['docker.io']" | sudo tee /etc/containers/registries.conf
+      # Install podman-compose
+      - sudo pip3 install podman-compose
+      - command -v podman-compose
+  - &docker
+    addons:
+    services: docker
+    before_install:
+
 matrix:
   include:
     # Run multi arch cases on only cron mode at first, as it takes 30+ minutes.
@@ -13,7 +39,8 @@ matrix:
       env: SERVICE=fedora30_aarch64 TARGETS="qemu build"
       if: type = cron
     - env: SERVICE=fedora30
-    - env: SERVICE=fedora29
+    - env: SERVICE=fedora29 DOCKER=docker
+      <<: *docker
     - env: SERVICE=fedora28
     - env: SERVICE=fedora27
     - env: SERVICE=fedora26
@@ -28,10 +55,11 @@ matrix:
   allow_failures:
     - env: SERVICE=fedora_rawhide
   fast_finish: true
+<<: *podman
 install: |
-  travis_retry make ${TARGETS} SERVICE=${SERVICE}
+  travis_retry make ${TARGETS} SERVICE=${SERVICE} DOCKER=${DOCKER}
 script: |
-  make test SERVICE=${SERVICE}
+  make test SERVICE=${SERVICE} DOCKER=${DOCKER}
 branches:
   only:
     - master

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SERVICE ?= fedora_rawhide
+DOCKER ?= podman
 CWD = $(shell pwd)
 
 default : build
@@ -6,26 +7,26 @@ default : build
 
 # Ex. make build SERVICE=fedora28
 build :
-	docker-compose build --force-rm $(SERVICE)
+	$(DOCKER)-compose build $(SERVICE)
 .PHONY : build
 
 # Ex. make test SERVICE=fedora28
 test :
-	docker-compose run --rm -v "$(CWD):/work" -w /work $(SERVICE)
+	$(DOCKER)-compose run --rm -v "$(CWD):/work" -w /work $(SERVICE)
 .PHONY : test
 
 # Ex. make login SERVICE=fedora28
 login :
-	docker run -v "$(CWD):/work" -w /work -it rpm-py-installer_$(SERVICE) bash
+	"$(DOCKER)" run -v "$(CWD):/work" -w /work -it rpm-py-installer_$(SERVICE) bash
 .PHONY : login
 
 build-no-volume :
-	docker build --rm \
+	"$(DOCKER)" build --rm \
 		-t rpm-py-installer_$(SERVICE) \
 		-f ci/Dockerfile-fedora \
 		--build-arg CONTAINER_IMAGE=$(CONTAINER_IMAGE) \
 		.
-	docker build --rm \
+	"$(DOCKER)" build --rm \
 		-t rpm-py-installer_$(SERVICE)_test \
 		-f ci/Dockerfile-test \
 		--build-arg CONTAINER_IMAGE=rpm-py-installer_$(SERVICE) \
@@ -33,7 +34,7 @@ build-no-volume :
 .PHONY : build-no-volume
 
 test-no-volume :
-	docker run --rm \
+	"$(DOCKER)" run --rm \
 		-t \
 		-e TOXENV=$(TOXENV) \
 		rpm-py-installer_$(SERVICE)_test \
@@ -45,9 +46,9 @@ no-network-test :
 .PHONY : no-network-test
 
 qemu :
-	docker-compose run --rm $@
+	$(DOCKER)-compose run --rm $@
 .PHONY : qemu
 
 clean :
-	docker system prune -a -f
+	"$(DOCKER)" system prune -a -f
 .PHONY : clean


### PR DESCRIPTION
Working in progress related to https://github.com/junaruga/rpm-py-installer/issues/193 .

Current situation is `podman-compose build` does not have `podman-compose build [SERVICE...]` and `--force-rm` option unlike `docker-compose`.

```
$ pip3 list
Package        Version 
...
podman-compose 0.1.5
...

$ podman-compose build --help
usage: podman-compose build [-h] [--pull] [--pull-always]

optional arguments:
  -h, --help     show this help message and exit
  --pull         attempt to pull a newer version of the image
  --pull-always  attempt to pull a newer version of the image, Raise an error
                 even if the image is present locally.
```

```
$ docker-compose version
docker-compose version 1.22.0, build f46880f
docker-py version: 3.7.0
CPython version: 3.7.4
OpenSSL version: OpenSSL 1.1.1c FIPS  28 May 2019

$ docker-compose build --help
Build or rebuild services.

Services are built once and then tagged as `project_service`,
e.g. `composetest_db`. If you change a service's `Dockerfile` or the
contents of its build directory, you can run `docker-compose build` to rebuild it.

Usage: build [options] [--build-arg key=val...] [SERVICE...]

Options:
    --compress              Compress the build context using gzip.
    --force-rm              Always remove intermediate containers.
    --no-cache              Do not use cache when building the image.
    --pull                  Always attempt to pull a newer version of the image.
    -m, --memory MEM        Sets memory limit for the build container.
    --build-arg key=val     Set build-time variables for services.
```

