### PR TITLE
Change aarch64 case to s390x case in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     # Run multi arch cases on only cron mode at first, as it takes 30+ minutes.
     - name: fedora30_s390x
       env: SERVICE=fedora30_s390x TARGETS="qemu build"
-      # if: type = cron
+      if: type = cron
     - env: SERVICE=fedora30
     - env: SERVICE=fedora29
     - env: SERVICE=fedora28

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ env:
 matrix:
   include:
     # Run multi arch cases on only cron mode at first, as it takes 30+ minutes.
-    - name: fedora30_aarch64
-      env: SERVICE=fedora30_aarch64 TARGETS="qemu build"
-      if: type = cron
+    - name: fedora30_s390x
+      env: SERVICE=fedora30_s390x TARGETS="qemu build"
+      # if: type = cron
     - env: SERVICE=fedora30
     - env: SERVICE=fedora29
     - env: SERVICE=fedora28

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,13 @@ services:
     environment:
       TOXENV: ${TOXENV-lint-py3,lint-py2,py37-cov,py27-cov}
     command: tox
-  fedora30_aarch64:
-    container_name: fedora30_aarch64
+  fedora30_s390x:
+    container_name: fedora30_s390x
     build:
       context: .
       dockerfile: ci/Dockerfile-fedora
       args:
-        CONTAINER_IMAGE: arm64v8/fedora:30
+        CONTAINER_IMAGE: s390x/fedora:30
     environment:
       TOXENV: ${TOXENV-py37}
     command: tox


### PR DESCRIPTION
* aarch64 is already tested on Shippable.
* Travis started supporting a native aarch64 environment.
  We do not need to use QEMU to run aarch64 case on Travis.
* There is no CI supporting native s390x environment so far.
  It's worth to run s390x case on QEMU.