### PR TITLE
Travis: Change branches setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,9 @@ script: |
 branches:
   only:
     - master
-    # Enable "pull/*" branches to run Travis CI on forked repository.
     - /^pull\//
+branches:
+  except:
+    # Enable branches except the working in progress branch or
+    # current pull-request feature/ci-podman and feature/ci-centos.
+    - /^(wip\/|feature\/(ci-podman|ci-centos5))/


### PR DESCRIPTION
Enable branches except the working in progress branch or
current pull-request feature/ci-podman and feature/ci-centos.
It makes users easier to run Travis on their forked repository.