### PR TITLE
Fix IndexError by lang specific rpm version output

### DIFF
--- a/install.py
+++ b/install.py
@@ -1944,7 +1944,9 @@ class Cmd(object):
         # * LC_ALL=C.UTF-8 shows a warning
         #   "cannot change locale (*) No such file or directory" on CentOS7.
         # * LC_ALL=en_US.UTF-8 shows the warning on Fedora 30.
-        env['LC_ALL'] = ''
+        env['LC_ALL'] = 'C'
+        if 'LANGUAGE' in env:
+            del env['LANGUAGE']
         if 'env' in kwargs:
             env.update(kwargs['env'])
         cmd_kwargs['env'] = env


### PR DESCRIPTION
My CentOS7 with de_DE.UTF8 runs into IndexError (via pip3 install), because output of rpm --version is then 'RPM-Version 4.11.3' instead of 'RPM version 4.11.3'.
Correctly reset locales by setting LC_ALL to C therefore overriding all locale categories and unsetting the GNU-specific LANGUAGE env var. Co-developed with a Unix-expert @mirabilos . Tested locally via pip3 install -e localpath.