### PR TITLE
Fix "Operation not permitted" issue on Fedora rawhide.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: bash
 services: docker
 git:

--- a/ci/Dockerfile-fedora
+++ b/ci/Dockerfile-fedora
@@ -31,7 +31,6 @@ RUN ARCH=$(rpm -q rpm --qf "%{arch}") \
   /usr/bin/python3.6 \
   /usr/bin/python3.5 \
   /usr/bin/python2.7 \
-  /usr/bin/python2.6 \
   # -- RPM packages required for a specified case --
   # Used to get the rpm-python by git commmand,
   # if a target rpm archive URL is not found on the server.
@@ -45,6 +44,11 @@ RUN ARCH=$(rpm -q rpm --qf "%{arch}") \
   # -- RPM packages for testing --
   apt \
   which
+# Optinally installed in some cases.
+RUN ARCH=$(rpm -q rpm --qf "%{arch}") \
+  && dnf -y --forcearch "${ARCH}" install \
+  /usr/bin/python2.6 \
+  || true
 
 RUN ./dnf_install_lint_pkgs.sh
 RUN dnf clean all

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       args:
         CONTAINER_IMAGE: fedora:rawhide
     environment:
-      TOXENV: ${TOXENV-py37,py27}
+      TOXENV: ${TOXENV-py37}
     command: tox
   # Integration
   intg:


### PR DESCRIPTION
```
Step 12/20 : RUN ls -1 /etc/yum.repos.d/*.repo
 ---> Running in 1b4ff4593a2f
ls: cannot access '/etc/yum.repos.d/fedora-cisco-openh264.repo': Operation not permitted
ls: cannot access '/etc/yum.repos.d/fedora-modular.repo': Operation not permitted
ls: cannot access '/etc/yum.repos.d/fedora-rawhide-modular.repo': Operation not permitted
ls: cannot access '/etc/yum.repos.d/fedora-rawhide.repo': Operation not permitted
ls: cannot access '/etc/yum.repos.d/fedora-updates-modular.repo': Operation not permitted
ls: cannot access '/etc/yum.repos.d/fedora-updates-testing-modular.repo': Operation not permitted
ls: cannot access '/etc/yum.repos.d/fedora-updates-testing.repo': Operation not permitted
ls: cannot access '/etc/yum.repos.d/fedora-updates.repo': Operation not permitted
ls: cannot access '/etc/yum.repos.d/fedora.repo': Operation not permitted
```

https://travis-ci.org/github/junaruga/rpm-py-installer/jobs/735991601#L216