### PR TITLE
Travis: Run Fedora cases except on cron mode.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,11 @@ matrix:
       if: type = cron
     - env: SERVICE=fedora30
     - env: SERVICE=fedora29
+      if: type = cron
     - env: SERVICE=fedora28
+      if: type = cron
     - env: SERVICE=fedora27
+      if: type = cron
     - env: SERVICE=fedora26
     - env: SERVICE=fedora_rawhide
     - env: SERVICE=intg


### PR DESCRIPTION
Run the following Fedora cases on Travis normally to save the CI running time.

* Fedora newest stable version
* Fedora oldest stable version
* Fedora rawhide.