### PR TITLE
Fix Ubuntu trusty "RuntimeError: Python 3.5 or later is required" error

### DIFF
--- a/ci/Dockerfile-ubuntu.trusty
+++ b/ci/Dockerfile-ubuntu.trusty
@@ -1,7 +1,7 @@
 FROM ubuntu:trusty
 
 WORKDIR /build
-COPY tox-requirements.txt .
+COPY tox-py34-requirements.txt .
 
 RUN apt-get update
 RUN apt-get install -y \
@@ -14,4 +14,4 @@ RUN apt-get install -y \
   # -- RPM packages required for a specified case --
   git
 RUN apt-get clean all
-RUN python3 -m pip install --upgrade -rtox-requirements.txt
+RUN python3 -m pip install --upgrade -rtox-py34-requirements.txt

--- a/tox-py34-requirements.txt
+++ b/tox-py34-requirements.txt
@@ -1,0 +1,15 @@
+# pip 19.2 dropped Python 3.4 support.
+# https://discuss.python.org/t/pip-19-2-is-now-available/2022
+pip<19.2
+# setuptools 44.0.0 dropped Python 3.4 support.
+# https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v4400
+setuptools<44.0.0
+# For Python 2.6.
+# https://github.com/pypa/virtualenv/commit/73404cb
+virtualenv<16.0.0
+# For Python 2.6.
+# Upstream changed to use "python -m pip", but Pytyon 2.6 does not support it.
+# https://github.com/tox-dev/tox/commit/e057755
+tox<3.2
+# tox on Ubuntu trusty Python 3.4 case needs pathlib2 to run.
+pathlib2


### PR DESCRIPTION
This PR is to fix the dependency error on Ubuntu trusty case.
See https://travis-ci.org/github/junaruga/rpm-py-installer/jobs/740418632#L825 for detail.

