### PR TITLE
opensuse: fix "No provider of 'python2-tox' found."

### DIFF
--- a/ci/Dockerfile-opensuse
+++ b/ci/Dockerfile-opensuse
@@ -5,4 +5,19 @@ WORKDIR /build
 COPY tox-requirements.txt .
 
 RUN zypper --non-interactive dup
-RUN zypper --non-interactive in python3-tox python2-tox git gcc python3-devel python-devel python2-setuptools python3-setuptools
+RUN zypper --non-interactive in \
+  cpio \
+  python3-tox \
+  git \
+  gcc \
+  python3-devel \
+  python-devel \
+  python2-setuptools \
+  python3-setuptools \
+  python-xml
+# librpmbuild%{librpmsover} package needed to build the RPM Python binding.
+# https://build.opensuse.org/package/view_file/openSUSE:Factory/rpm/rpm.spec
+# TODO: Install it in the process of rpm-py-installer.
+RUN zypper --non-interactive in \
+  librpmbuild9 \
+  || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
       args:
         CONTAINER_IMAGE: opensuse/tumbleweed
     environment:
-      TOXENV: ${TOXENV-py37-cov,py27-cov}
+      TOXENV: ${TOXENV-py3-cov}
     command: tox
   # https://hub.docker.com/r/opensuse/leap
   opensuse_leap_15:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint-py{3,2},py{37,36,35,34,27,26}{-cov,}
+envlist = lint-py{3,2},py{3,39,38,37,36,35,34,2,27,26}{-cov,}
 # Do not run actual install process in tox.
 skipsdist = True
 


### PR DESCRIPTION
This PR is to fix the following error on Open SuSE tumbleweed case.

https://travis-ci.org/github/junaruga/rpm-py-installer/jobs/740454002#L221

```
'python3-devel' not found in package names. Trying capabilities.
'python2-tox' not found in package names. Trying capabilities.
No provider of 'python2-tox' found.
```