### PR TITLE
Enable no_network marker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
     - env: SERVICE=fedora29
       if: type = cron
     - env: SERVICE=fedora28
-      if: type = cron
     - env: SERVICE=fedora27
       if: type = cron
     - env: SERVICE=fedora26

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-no-volume :
 .PHONY : test-no-volume
 
 no-network-test :
-	pytest -m 'not network'
+	pytest -m no_network
 .PHONY : no-network-test
 
 qemu :

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,10 @@ def pytest_collection_modifyitems(items):
             pass
         else:
             item.add_marker(pytest.mark.unit)
+        if item.get_marker('network') is not None:
+            pass
+        else:
+            item.add_marker(pytest.mark.no_network)
 
 
 @pytest.fixture


### PR DESCRIPTION
Because I can not find the way to do shell escape the space
in the following option value in container.

```
pytest -m 'not network'
```

The new option is used like this.

```
pytest -m no_network
```