### PR TITLE
Travis: Remove the unused part of the branches syntax.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,11 +60,7 @@ install: |
 script: |
   make test
 branches:
-  only:
-    - master
-    - /^pull\//
-branches:
   except:
     # Enable branches except the working in progress branch or
-    # current pull-request feature/ci-podman and feature/ci-centos.
-    - /^(wip\/|feature\/(ci-podman|ci-centos5))/
+    # current pull-request feature/ci-centos.
+    - /^(wip\/|feature\/ci-centos5)/


### PR DESCRIPTION
The part is actually not loaded internally in Travis.
We can also remove "feature/ci-podman" branch setting, as we implemented
the podman feature.