### PR TITLE
DOCKER_VOLUME option to run "make" and "make test".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       env: IMAGE="fedora:27" TOXENV="py36"
       if: type = cron
     - name: fedora26
-      env: IMAGE="fedora:26" TOXENV="py35,py26"
+      env: DOCKER_VOLUME="false" IMAGE="fedora:26" TOXENV="py35,py26"
     - name: fedora_rawhide
       env: TOXENV="py37"
     - name: intg


### PR DESCRIPTION
Add a feature to run `make` and `make test` with `DOCKER_VOLUME` option.
    
It's an option to use the volume bind mount to build and test.
    
* true: It synchronizes the source between host and container. It's good in case of developing, modifying the code on host, testing in container.
* false: It's good to use on CIs that do not support the volume mount.
    
It can be used like this.
    
```
$ DOCKER_VOLUME=false make --trace
Makefile:48: target 'build-volume-false' does not exist
...

$ DOCKER_VOLUME=false make test --trace
Makefile:62: target 'test-volume-false' does not exist
...
```
    
If you see a permission error in tests with podman, try the `DOCKER_VOLUME=false`.
Possibly there is an issue related to the volume mount.