### PR TITLE
Add Python 3.8 and 3.9 support to setup.py.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,26 +9,21 @@ env:
     - TARGETS=""
 matrix:
   include:
+    # https://fedoraproject.org/wiki/Releases
     # https://hub.docker.com/_/fedora/
     # Run multi arch cases on only cron mode at first, as it takes 30+ minutes.
-    - name: fedora30_s390x
-      env: IMAGE="s390x/fedora:30" TOXENV="py37" TARGETS="qemu build"
+    - name: fedora33_s390x
+      env: IMAGE="s390x/fedora:33" TOXENV="py3" TARGETS="qemu build"
       if: type = cron
-    - name: fedora30
-      env: IMAGE="fedora:30" TOXENV="lint-py3,lint-py2,py37-cov,py27-cov" TEST_LINT="true"
-    - name: fedora29
-      env: IMAGE="fedora:29"
-      if: type = cron
-    - name: fedora28
-      env: DOCKER="podman" IMAGE="fedora:28" TOXENV="py36"
+    - name: fedora33
+      env: IMAGE="fedora:33" TOXENV="lint-py3,lint-py2,py38-cov" TEST_LINT="true"
+    - name: fedora32
+      env: DOCKER="podman" IMAGE="fedora:32" TOXENV="py37,py27-cov"
       script: make no-network-test
-    - name: fedora27
-      env: IMAGE="fedora:27" TOXENV="py36"
-      if: type = cron
-    - name: fedora26
-      env: DOCKER_VOLUME="false" IMAGE="fedora:26" TOXENV="py35,py26"
+    - name: fedora31
+      env: DOCKER_VOLUME="false" IMAGE="fedora:31" TOXENV="py36,py35,py26"
     - name: fedora_rawhide
-      env: TOXENV="py37"
+      env: TOXENV="py39"
     - name: intg
       env: TOXENV="intg"
     # https://hub.docker.com/_/centos/

--- a/ci/Dockerfile-fedora
+++ b/ci/Dockerfile-fedora
@@ -27,6 +27,8 @@ RUN ARCH=$(rpm -q rpm --qf "%{arch}") \
   gcc \
   python3-devel \
   python2-devel \
+  /usr/bin/python3.9 \
+  /usr/bin/python3.8 \
   /usr/bin/python3.7 \
   /usr/bin/python3.6 \
   /usr/bin/python3.5 \

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,8 @@ See "Homepage" on GitHub for detail.
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: System :: Installation/Setup',
     ],
     scripts=[

--- a/test-lint-requirements.txt
+++ b/test-lint-requirements.txt
@@ -1,5 +1,5 @@
 # Code Analysis for Python
-flake8==3.5.0
+flake8<3.9
 flake8-colors
 flake8-isort
 # Restrict version to test on Python 2.6.

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ whitelist_externals =
 commands =
     flake8 --version
     # Use bash -c to use wildcard.
-    bash -c 'flake8 --show-source --statistics pm_py_installer/ *.py tests/'
+    bash -c 'flake8 --show-source --statistics rpm_py_installer/ *.py tests/'
     bash -c 'pydocstyle rpm_py_installer/ *.py'
     bash scripts/lint_bash.sh
 


### PR DESCRIPTION
Rebase Fedora CI cases to the latest versions.

The current latest Python is 3.9.0.
https://www.python.org/

The current latest Fedora is f34 (rawhide), f33 (latest stable).
https://fedoraproject.org/wiki/Releases for detail.

f30 is end of life.
https://fedoraproject.org/wiki/End_of_life

So, we cover the f34 (rawhide) to f31 for now.
