### PR TITLE
Support CentOS 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,10 @@ matrix:
     - name: intg
       env: TOXENV="intg"
     # https://hub.docker.com/_/centos/
+    - name: centos8
+      env: DOCKERFILE="ci/Dockerfile-centos" IMAGE="centos:8" TOXENV="py36-cov,py27-cov"
     - name: centos7
-      env: DOCKERFILE="ci/Dockerfile-centos.7" TOXENV="py36-cov,py34-cov,py27-cov"
+      env: DOCKERFILE="ci/Dockerfile-centos" IMAGE="centos:7" TOXENV="py36,py34-cov,py27"
     - name: centos6
       env: DOCKER_VOLUME="false" DOCKERFILE="ci/Dockerfile-centos.6" TOXENV="py27,py26"
     # https://hub.docker.com/_/ubuntu/

--- a/ci/Dockerfile-centos
+++ b/ci/Dockerfile-centos
@@ -1,4 +1,5 @@
-FROM centos:7
+ARG CONTAINER_IMAGE=centos:8
+FROM ${CONTAINER_IMAGE}
 
 WORKDIR /build
 COPY tox-requirements.txt .
@@ -13,17 +14,21 @@ RUN yum -y install \
   rpm-libs \
   redhat-rpm-config \
   gcc \
+  python3-devel \
   python36-devel \
-  python34-devel \
-  python-devel \
+  python2-devel \
   /usr/bin/python3.6 \
-  /usr/bin/python3.4 \
   /usr/bin/python2.7 \
   # -- RPM packages required for a specified case --
   /usr/bin/git \
   rpm-build-libs \
   /usr/bin/yumdownloader \
-  /usr/bin/cpio \
-  && yum clean all
+  /usr/bin/cpio
+# Install on CentOS 7, but not CentOS 8.
+RUN yum -y install \
+  python34-devel \
+  /usr/bin/python3.4 \
+  || true
+RUN yum clean all
 RUN python3 -m ensurepip
 RUN python3 -m pip install --upgrade -rtox-requirements.txt

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -703,7 +703,7 @@ def test_installer_init_is_ok(installer):
                     not pytest.helpers.is_root_user(),
                     reason="Can only run zypper as root.")
 def test_installer_install_from_rpm_py_package(
-    installer, is_debian, is_centos, monkeypatch
+    installer, is_debian, is_centos, os_version, monkeypatch
 ):
     with pytest.helpers.work_dir():
         # The RPM Python binding for python3 is not provided on CentOS.
@@ -711,7 +711,7 @@ def test_installer_install_from_rpm_py_package(
         # http://mirror.centos.org/centos/7/os/x86_64/Packages/
         if is_debian or \
            not installer._predict_rpm_py_package_names() or \
-           (is_centos and sys.version_info >= (3, 0)):
+           (is_centos and os_version < 8 and sys.version_info >= (3, 0)):
             with pytest.raises(RpmPyPackageNotFoundError):
                 installer.install_from_rpm_py_package()
         else:


### PR DESCRIPTION
This PR is after the PR: https://github.com/junaruga/rpm-py-installer/pull/237 .

Possibly the py36 case on CentOS 8 fails with the following error. I checked it on local.

```
>                   installer.install_from_rpm_py_package()
E                   Failed: DID NOT RAISE <class 'install.RpmPyPackageNotFoundError'>
tests/test_install.py:716: Failed
```

```
def test_installer_install_from_rpm_py_package(
    installer, is_debian, is_centos, monkeypatch
):
    with pytest.helpers.work_dir():
        # The RPM Python binding for python3 is not provided on CentOS.
        # rpm-python3 does not exist on CentOS.
        # http://mirror.centos.org/centos/7/os/x86_64/Packages/
        if is_debian or \ 
           not installer._predict_rpm_py_package_names() or \ 
           (is_centos and sys.version_info >= (3, 0)): 
            with pytest.raises(RpmPyPackageNotFoundError):
                installer.install_from_rpm_py_package() # <= the line 716.
```



The reason is because there is `python3-rpm-4.14.2-37.el8.x86_64.rpm` package on http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/ . `python2-rpm` and `python-rpm` do not exist.

The solution is checking `VERSION_ID` in the process of the test.
Here is the `/etc/os-release ` on CentOS 8.

```
$ podman run --rm -it centos:8 bash
[root@1acda2c8fb56 /]# cat /etc/os-release 
NAME="CentOS Linux"
VERSION="8 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="8"
PLATFORM_ID="platform:el8"
PRETTY_NAME="CentOS Linux 8 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:8"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-8"
CENTOS_MANTISBT_PROJECT_VERSION="8"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="8"
```
