### PR TITLE
Provide fake compatibility option setup.py bdist -d/dist-dir=

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,14 +65,16 @@ class BdistWheelCommand(Command):
     See https://github.com/pypa/pip/issues/4720
     """
 
-    user_options = []
+    user_options = [
+        ("dist-dir=", "d", "For compatibility. Ignored."),
+    ]
 
     def initialize_options(self):
         """Initilize options.
 
         Just extend the super class's abstract method.
         """
-        pass
+        self.dist_dir = None
 
     def finalize_options(self):
         """Finalize options.


### PR DESCRIPTION
pip install now calls: setup.py bdist_wheel -d /tmp/directory/ . Since
it is able to determine available options in declarative way, code
doesn't even try to run our overloaded run() which raises an exception
that wheels are not supported.

This change add options -d/dist-dir= so run() is executed and we have a
chance to raise an exception (and thus fail) bdist wheel build our own
way.

Fixes #102