### PR TITLE
Discard extra lines when parsing pip JSON output

### DIFF
--- a/install.py
+++ b/install.py
@@ -1544,7 +1544,7 @@ class Python(object):
 
     def _get_pip_list_json_obj(self):
         cmd = '{0} list --format json'.format(self._get_pip_cmd())
-        json_str = Cmd.sh_e_out(cmd)
+        json_str = Cmd.sh_e_out(cmd).split('\n')[0]
         json_obj = json.loads(json_str)
         return json_obj
 


### PR DESCRIPTION
pip tends to append notices about new pip version being available to the end of its standard output, e.g.:

```
{valid JSON string}

[notice] A new release of pip available: 22.1.2 -> 22.2.1
[notice] To update, run: pip install --upgrade pip
```

Ignore those.
