### PR TITLE
Set `fail-fast: false`.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,6 +19,7 @@ jobs:
     needs: matrix-preparation
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.matrix-preparation.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I like to set the `fail-fast` [1] to the CI, as it's convenient to see all the results on the CI at once.

Previously the CI result is https://github.com/junaruga/rpm-py-installer/actions/runs/2767206553 .
After this PR, the result is https://github.com/junaruga/rpm-py-installer/actions/runs/2767252841 .

What do you think?

[1] https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
