### PR TITLE
A temporary workaround not to use flake8 version 5.

### DIFF
--- a/test-lint-requirements.txt
+++ b/test-lint-requirements.txt
@@ -1,5 +1,7 @@
 # Code Analysis for Python
-flake8
+# A temporary workaround not to use flake8 version 5.
+# https://github.com/gforcada/flake8-isort/issues/115
+flake8 < 5
 flake8-colors
 flake8-isort
 isort


### PR DESCRIPTION
The flake8-isort old version 3.0.0 is installed with flake8 5.0.0,
and it exists with error.

This fixes #248.
