### PR TITLE
Change the name of the GitHub Actions yml file.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-name: Build test images and run the tests
+name: build
 on:
   push:
   pull_request:


### PR DESCRIPTION
Because it is used of the build status badge image text. A simple name is good.

See https://github.com/junaruga/rpm-py-installer/blob/wip/gha-badge-image/README.md . The badge image's text is too long.

![screenshot-github com-2022 07 31-00_27_33](https://user-images.githubusercontent.com/121989/182002216-7f6d0893-6ac5-4dcb-ba5f-90d4b6d6e249.png)

I referred the links below.

* https://github.com/rebase-helper/rebase-helper/blob/ecb65b8e0135ae80f1cc4635dcfcdd91d18ef72c/.github/workflows/ci.yml#L1
* https://github.com/ruby/ruby/blob/118368c1dd9304c0c21a4437016af235bd9b8438/.github/workflows/compilers.yml#L1


