### PR TITLE
Print PIP version in the test.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,8 @@ deps =
 whitelist_externals =
     bash
 commands =
+    python --version
+    python -m pip --version
     flake8 --version
     # Use bash -c to use wildcard.
     bash -c 'flake8 --show-source --statistics rpm_py_installer/ *.py tests/'

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ whitelist_externals =
     rpm
 commands =
     python --version
+    python -m pip --version
     rpm --version
     pytest \
         -m unit \


### PR DESCRIPTION
This improvement comes from https://github.com/junaruga/rpm-py-installer/pull/246#issuecomment-1200295308 .

We can see depending pip package versions except pip version in the passed test case. But we can't see the PIP version in the passed case as far as I know.

This change enables us to check PIP version in the passed test case. It's convenient to debug a PIP version related issue from the CI logs.

It's printed like this.

https://github.com/junaruga/rpm-py-installer/runs/7598178557?check_suite_focus=true#step:10:55

```
py310-cov run-test: commands[1] | python -m pip --version
pip 22.2.1 from /work/.tox/py310-cov/lib/python3.10/site-packages/pip (python 3.10)
```

