### PR TITLE
Revive CentOS 6 and the Python 2.7 case.

### DIFF
--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -44,6 +44,12 @@
         "dockerfile": "ci/Dockerfile-centos.7"
     },
     {
+        "name": "centos_6",
+        "image": "centos:6",
+        "toxenv": "py27",
+        "dockerfile": "ci/Dockerfile-centos.6"
+    },
+    {
         "name": "ubuntu_bionic",
         "toxenv": "py36-cov,py27-cov",
         "dockerfile": "ci/Dockerfile-ubuntu.bionic"

--- a/ci/CentOS-Base.repo.centos6
+++ b/ci/CentOS-Base.repo.centos6
@@ -1,0 +1,33 @@
+[base]
+name=CentOS-$releasever - Base
+baseurl=http://vault.centos.org/6.10/os/$basearch
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#released updates
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=http://vault.centos.org/6.10/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=http://vault.centos.org/6.10/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#additional packages that extend functionality of existing packages
+[centosplus]
+name=CentOS-$releasever - Plus
+baseurl=http://vault.centos.org/6.10/centosplus/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#contrib - packages by Centos Users
+[contrib]
+name=CentOS-$releasever - Contrib
+baseurl=http://vault.centos.org/6.10/contrib/$basearch/
+gpgcheck=1

--- a/ci/Dockerfile-centos.6
+++ b/ci/Dockerfile-centos.6
@@ -1,0 +1,37 @@
+FROM centos:6
+
+WORKDIR /build
+COPY ci/CentOS-Base.repo.centos6 .
+COPY ci/install_python.sh .
+COPY tox-requirements.txt .
+
+# Use vault.centos.org server as a package repository, as the official CentOS 6
+# repository is not available any more
+# https://vault.centos.org/6.10/
+RUN cp -p ./CentOS-Base.repo.centos6 /etc/yum.repos.d/CentOS-Base.repo
+
+RUN yum -y update
+RUN yum -y install epel-release
+RUN yum -y install \
+  --setopt=deltarpm=0 \
+  --setopt=install_weak_deps=false \
+  --setopt=tsflags=nodocs \
+  # -- RPM packages required for installing --
+  rpm-libs \
+  redhat-rpm-config \
+  gcc \
+  zlib-devel \
+  openssl-devel \
+  bzip2-devel \
+  python-devel \
+  /usr/bin/yumdownloader \
+  /usr/bin/cpio \
+  # -- RPM packages required for a specified case --
+  /usr/bin/git \
+  && yum clean all
+
+RUN ./install_python.sh 2.7.14
+ENV PATH "/usr/local/python-2.7.14/bin:${PATH}"
+
+RUN python2.7 -m ensurepip
+RUN python2.7 -m pip install --upgrade -rtox-requirements.txt


### PR DESCRIPTION
This PR is to revive CentOS 6 case, and the Python 2.7 case that was dropped at the commit https://github.com/junaruga/rpm-py-installer/commit/3803edef333397f71f0f11d09bf21e71d422855a .

I used the http://vault.centos.org/6.10 as an alternative CentOS 6 repository. In this commit, I revived only Python 2.7 case, as I see an issue to revive Python 2.6 case on it.

I also referred to https://github.com/junaruga/rpm-py-installer/pull/171#issuecomment-462865135 .

