### PR TITLE
WIP: Revive Python 2.6 case on CentOS 6.

### DIFF
--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -46,7 +46,7 @@
     {
         "name": "centos_6",
         "image": "centos:6",
-        "toxenv": "py27",
+        "toxenv": "py27,py26",
         "dockerfile": "ci/Dockerfile-centos.6"
     },
     {

--- a/ci/Dockerfile-centos.6
+++ b/ci/Dockerfile-centos.6
@@ -3,7 +3,7 @@ FROM centos:6
 WORKDIR /build
 COPY ci/CentOS-Base.repo.centos6 .
 COPY ci/install_python.sh .
-COPY tox-requirements.txt .
+COPY tox-py26-requirements.txt .
 
 # Use vault.centos.org server as a package repository, as the official CentOS 6
 # repository is not available any more
@@ -24,6 +24,9 @@ RUN yum -y install \
   openssl-devel \
   bzip2-devel \
   python-devel \
+  # Python 2.6
+  python-devel \
+  /usr/bin/python2.6 \
   /usr/bin/yumdownloader \
   /usr/bin/cpio \
   # -- RPM packages required for a specified case --
@@ -34,4 +37,4 @@ RUN ./install_python.sh 2.7.14
 ENV PATH "/usr/local/python-2.7.14/bin:${PATH}"
 
 RUN python2.7 -m ensurepip
-RUN python2.7 -m pip install --upgrade -rtox-requirements.txt
+RUN python2.7 -m pip install --upgrade -rtox-py26-requirements.txt

--- a/test-py26-requirements.txt
+++ b/test-py26-requirements.txt
@@ -1,0 +1,5 @@
+# Test
+pytest<4
+pytest-helpers-namespace
+# For Python <= 3.2
+backports.unittest_mock

--- a/tox-py26-requirements.txt
+++ b/tox-py26-requirements.txt
@@ -1,0 +1,11 @@
+pip
+setuptools
+# For Python 2.6.
+# https://github.com/pypa/virtualenv/commit/73404cb
+virtualenv<16.0.0
+# For Python 2.6.
+# Upstream changed to use "python -m pip", but Pytyon 2.6 does not support it.
+# https://github.com/tox-dev/tox/commit/e057755
+tox<3.2
+# tox on Ubuntu trusty Python 3.4 case needs pathlib2 to run.
+pathlib2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint-py{3,2},py{3,311,310,39,38,37,36,35,34,2,27}{-cov,}
+envlist = lint-py{3,2},py{3,311,310,39,38,37,36,35,34,2,27,26}{-cov,}
 # Do not run actual install process in tox.
 skipsdist = True
 
@@ -24,6 +24,16 @@ commands =
     cov:    --cov-report term \
     cov:    --cov-report html \
         {posargs}
+
+[testenv:py26]
+deps =
+    -rtest-py26-requirements.txt
+whitelist_externals = {[testenv]whitelist_externals}
+commands =
+    python --version
+    python -m pip --version
+    rpm --version
+    pytest -m unit {posargs}
 
 [testenv:intg]
 deps =


### PR DESCRIPTION
I am trying to revive Python 2.6 case on CentOS 6 on GitHub Actions. I picked up the added files from the past commit.

However I am seeing an issue below. So, if you find something to fix it, please let me know. Thanks.
https://github.com/junaruga/rpm-py-installer/runs/7611264388?check_suite_focus=true#step:10:212
