### PR TITLE
Update supported Python versions in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,6 @@ See "Homepage" on GitHub for detail.
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
@@ -121,6 +120,8 @@ See "Homepage" on GitHub for detail.
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: System :: Installation/Setup',
     ],
     scripts=[


### PR DESCRIPTION
* Added Python 3.11, 3.10.
* Dropped Python 2.6.
  Because we can't run the test on Python 2.6 on CentOS 6 any more. See this PR: https://github.com/junaruga/rpm-py-installer/pull/256 for details.
  
  