### PR TITLE
matrix_includes.json: Add Fedora 37, and drop Fedora 34.

### DIFF
--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -1,7 +1,7 @@
 [
     {
-        "name": "fedora_36_s390x",
-        "image": "s390x/fedora:36",
+        "name": "fedora_37_s390x",
+        "image": "s390x/fedora:37",
         "toxenv": "py3",
         "test_lint": true,
         "docker": "docker",
@@ -9,19 +9,19 @@
         "cron": true
     },
     {
-        "name": "fedora_36",
-        "image": "fedora:36",
+        "name": "fedora_37",
+        "image": "fedora:37",
         "toxenv": "lint-py3,py310-cov",
         "test_lint": true
     },
     {
-        "name": "fedora_35",
-        "image": "fedora:35",
+        "name": "fedora_36",
+        "image": "fedora:36",
         "toxenv": "py310"
     },
     {
-        "name": "fedora_34",
-        "image": "fedora:34",
+        "name": "fedora_35",
+        "image": "fedora:35",
         "toxenv": "py39,py38",
         "docker_volume": false
     },

--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -11,7 +11,7 @@
     {
         "name": "fedora_37",
         "image": "fedora:37",
-        "toxenv": "lint-py3,py310-cov",
+        "toxenv": "lint-py3,py311-cov",
         "test_lint": true
     },
     {


### PR DESCRIPTION
See <https://ask.fedoraproject.org/t/fedora-37-released-fedora-35-reaches-end-of-life-in-december-22/28538>.

--

I am seeing the error below on Fedora 37, when I executed. Any idea how to fix?

https://github.com/junaruga/rpm-py-installer/actions/runs/3507961554/jobs/5876036926#step:10:360

```
E               install.CmdError: CMD: [/work/.tox/py310-cov/bin/python setup.py -q build], Return Code: [1] at [/tmp/tmpifmn6s4t-rpm-py-installer/rpm-rpm-4.18.0-release/python] Stderr: [/work/.tox/py310-cov/lib64/python3.10/site-packages/coverage/inorout.py:472: CoverageWarning: --include is ignored because --source is set (include-ignored)
E                 self.warn("--include is ignored because --source is set", slug="include-ignored")
E               In file included from header-py.c:1:
E               rpmsystem-py.h:9:10: fatal error: Python.h: No such file or directory
E                   9 | #include <Python.h>
E                     |          ^~~~~~~~~~
E               compilation terminated.
E               error: command '/usr/bin/gcc' failed with exit code 1
E               ]
```