### PR TITLE
Add the `Operating System :: POSIX :: Linux`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ See "Homepage" on GitHub for detail.
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'System :: POSIX :: Linux',
         'Topic :: System :: Installation/Setup',
     ],
     scripts=[


### PR DESCRIPTION
To emphasize only supporting Linux right now. There is no support for MacOS right now.

It was mentioned at https://github.com/junaruga/rpm-py-installer/issues/155#issuecomment-1328216336 .

It makes the rpm-py-installer searchable by https://pypi.org/search/?c=Operating+System+%3A%3A+POSIX+%3A%3A+Linux .

I checked the name by a random pip package.
https://github.com/oremanj/tricycle/blob/master/setup.py#L25

