### PR TITLE
CI opensuse tumbleweed: Add missing tomli pypi package.

### DIFF
--- a/ci/Dockerfile-opensuse
+++ b/ci/Dockerfile-opensuse
@@ -8,6 +8,7 @@ RUN zypper --non-interactive dup
 RUN zypper --non-interactive in \
   cpio \
   python3-tox \
+  python3-tomli \
   git \
   gcc \
   python3 \


### PR DESCRIPTION
To fix the CI failures.
<https://github.com/junaruga/rpm-py-installer/actions/runs/3577605119/jobs/6016798011>.
It seems that tox requires the "tomli" package.

```
$ make login IMAGE=opensuse/tumbleweed
"podman" run -t -v "/home/jaruga/var/git/rpm-py-installer:/work:Z" -w /work -it rpm-py-installer_opensuse/tumbleweed bash

7344f4387a04:/work # tox --version
3.26.0 imported from /usr/lib/python3.10/site-packages/tox/__init__.py

7344f4387a04:/work # tox -l
Traceback (most recent call last):
  File "/usr/bin/tox", line 5, in <module>
    from tox import cmdline
  File "/usr/lib/python3.10/site-packages/tox/__init__.py", line 32, in <module>
    from .session import cmdline  # isort:skip
  File "/usr/lib/python3.10/site-packages/tox/session/__init__.py", line 22, in <module>
    from tox.config import INTERRUPT_TIMEOUT, SUICIDE_TIMEOUT, TERMINATE_TIMEOUT, parseconfig
  File "/usr/lib/python3.10/site-packages/tox/config/__init__.py", line 30, in <module>
    import tomli as toml_loader
ModuleNotFoundError: No module named 'tomli'
```