### PR TITLE
CI ubuntu trusty: Add zipp<3.11 dependency to pass the CI.

### DIFF
--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -51,11 +51,13 @@
     },
     {
         "name": "ubuntu_bionic",
+        "image": "ubuntu:bionic",
         "toxenv": "py36-cov,py27-cov",
         "dockerfile": "ci/Dockerfile-ubuntu.bionic"
     },
     {
         "name": "ubuntu_trusty",
+        "image": "ubuntu:trusty",
         "toxenv": "py34",
         "dockerfile": "ci/Dockerfile-ubuntu.trusty"
     },

--- a/tox-py34-requirements.txt
+++ b/tox-py34-requirements.txt
@@ -11,3 +11,6 @@ setuptools<44.0.0
 pathlib2
 virtualenv<16.0.0
 tox<3.2
+# The zipp 3.11.0 doesn't work in Python 3.4.
+# https://github.com/jaraco/zipp/issues/87
+zipp<3.11


### PR DESCRIPTION
This PR has 2 commits.

* CI: Add image names to Ubuntu cases
  This commit is to guide how to test the Ubuntu cases in a better way.
  The image name is required to create the local image name correctly except the
  case using the Fedora rawhide image. Without the image name, the image is
  created as "rpm-py-installer_fedora:rawhide"
  https://github.com/junaruga/rpm-py-installer/actions/runs/3577605119/jobs/6016797903#step:9:678
  > Successfully tagged localhost/rpm-py-installer_fedora:rawhide

* CI ubuntu trusty: Add zipp<3.11 dependency to pass the CI.
   The main commit. You can see https://github.com/jaraco/zipp/issues/87 for details.
   