### PR TITLE
setup.py: Enhance to print stdout and stderr messages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 """Classes to set up and install rpm-py-installer."""
-import os
+import subprocess
 import sys
 from distutils.cmd import Command
 
@@ -11,13 +11,36 @@ from setuptools.command.install import install
 from rpm_py_installer.version import VERSION
 
 
+def run_cmd(cmd):
+    """Run a command."""
+    exit_status = 0
+    message = ''
+
+    proc = subprocess.Popen(
+        cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    proc.wait()
+    exit_status = proc.returncode
+    stdout = proc.stdout.read().decode()
+    stderr = proc.stderr.read().decode()
+    message = '''
+Command: {0}
+Return Code: [{1}]
+Stdout: [{2}]
+Stderr: [{3}]
+'''.format(cmd, exit_status, stdout, stderr)
+
+    return (exit_status, message)
+
+
 def install_rpm_py():
     """Install RPM Python binding."""
     python_path = sys.executable
     cmd = '{0} install.py'.format(python_path)
-    exit_status = os.system(cmd)
+    exit_status, message = run_cmd(cmd)
+
     if exit_status != 0:
-        raise Exception('Command failed: {0}'.format(cmd))
+        raise Exception(message)
 
 
 class InstallCommand(install):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -116,6 +116,21 @@ def test_install_and_uninstall_are_ok_on_sys_status(
     assert True
 
 
+def test_pip_install():
+    try:
+        _run_cmd('pip -q show rpm && pip uninstall -y rpm')
+        _run_cmd('pip -q show rpm-python && pip uninstall -y rpm-python')
+        _run_cmd(
+            'pip -q show rpm-py-installer '
+            '&& pip uninstall -y rpm-py-installer'
+        )
+        assert _run_cmd('pip install .')
+    finally:
+        _run_cmd('pip uninstall -y rpm-py-installer')
+        _run_cmd('pip -q show rpm && pip uninstall -y rpm')
+        _run_cmd('pip -q show rpm-python && pip uninstall -y rpm-python')
+
+
 def _assert_install_and_uninstall(install_script_path, **env):
     try:
         python_path = sys.executable


### PR DESCRIPTION
We want to see the stdout and stderr messages if the `python install.py` fails,

This PR is to capture stdout and stderr to check the details of the issue https://github.com/junaruga/rpm-py-installer/issues/260 .

## Python 3.11

Success case

```
$ source venv/bin/activate
(venv) $ pip install .
Processing /home/jaruga/var/git/rpm-py-installer
  Preparing metadata (setup.py) ... done
Using legacy 'setup.py install' for rpm-py-installer, since package 'wheel' is not installed.
Installing collected packages: rpm-py-installer
  Running setup.py install for rpm-py-installer ... done
Successfully installed rpm-py-installer-1.2.0

[notice] A new release of pip available: 22.2.2 -> 22.3.1
[notice] To update, run: pip install --upgrade pip
```

