### PR TITLE
tox.ini: Replace the `whitelist_externals` with `allowlist_externals`.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ skipsdist = True
 deps =
     -rtest-requirements.txt
     cov: -rtest-cov-requirements.txt
-whitelist_externals =
+allowlist_externals =
     rpm
 commands =
     python --version
@@ -28,7 +28,7 @@ commands =
 [testenv:intg]
 deps =
     -rtest-requirements.txt
-whitelist_externals =
+allowlist_externals =
     bash
 commands =
     pytest -m integration -s {posargs}
@@ -37,7 +37,7 @@ commands =
 skip_install = true
 deps =
     -rtest-lint-requirements.txt
-whitelist_externals =
+allowlist_externals =
     bash
 commands =
     python --version
@@ -52,12 +52,12 @@ commands =
 basepython = python3
 skip_install = {[lint]skip_install}
 deps = {[lint]deps}
-whitelist_externals = {[lint]whitelist_externals}
+allowlist_externals = {[lint]allowlist_externals}
 commands = {[lint]commands}
 
 [testenv:lint-py2]
 basepython = python2
 skip_install = {[lint]skip_install}
 deps = {[lint]deps}
-whitelist_externals = {[lint]whitelist_externals}
+allowlist_externals = {[lint]allowlist_externals}
 commands = {[lint]commands}


### PR DESCRIPTION
This PR fixes https://github.com/junaruga/rpm-py-installer/issues/268 .

The `whitelist_externals` was removed in tox 4.0.0rc4. See <https://github.com/tox-dev/tox/blob/main/docs/changelog.rst#deprecations-and-removals---400rc4>.
