### PR TITLE
Register marks to suppress the mark warnings.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,14 @@ envlist = lint-py{3,2},py{3,311,310,39,38,37,36,35,34,2,27}{-cov,}
 # Do not run actual install process in tox.
 skipsdist = True
 
+[pytest]
+markers=
+    unit: mark a test as a unit test.
+    integration: mark a test as an integration test.
+    network: mark a test as a test requiring a network.
+    no_network: mark a test as a test not requiring a network.
+testpaths=tests
+
 # {posargs}: Arguments after $ tox options --.
 # See http://tox.readthedocs.io/en/latest/example/general.html
 # ex. to test only tests/test_something.py, outputting stdout/stderr (-s).


### PR DESCRIPTION
This fixes the warnings like below.

I referred to the rebase-helper :)
https://github.com/rebase-helper/rebase-helper/blob/d4a98d5b6bdb11338ba514cee5bd5a434ecd98fe/tox.ini#L7-L12


```
 tests/test_install.py:128
  /work/tests/test_install.py:128: PytestUnknownMarkWarning: Unknown pytest.mark.network - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.network

 tests/test_integration.py:11
  /work/tests/test_integration.py:11: PytestUnknownMarkWarning: Unknown pytest.mark.integration - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.integration

tests/conftest.py:86
  /work/tests/conftest.py:86: PytestUnknownMarkWarning: Unknown pytest.mark.unit - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    item.add_marker(pytest.mark.unit)

tests/conftest.py:90
  /work/tests/conftest.py:90: PytestUnknownMarkWarning: Unknown pytest.mark.no_network - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    item.add_marker(pytest.mark.no_network)
```