### PR TITLE
Print the used tox version in the tox tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,10 +20,12 @@ deps =
     -rtest-requirements.txt
     cov: -rtest-cov-requirements.txt
 allowlist_externals =
+    tox
     rpm
 commands =
     python --version
     python -m pip --version
+    tox --version
     rpm --version
     pytest \
         -m unit \


### PR DESCRIPTION
It's convenient to report an issue related to the tox to an upstream project.

You can see the tox version at https://github.com/junaruga/rpm-py-installer/actions/runs/3661228992/jobs/6189235460#step:10:16

Related to https://github.com/junaruga/rpm-py-installer/issues/270#issuecomment-1344829856 , I want to report the `pip list`'s empty result issue to the tox project. 
