### PR TITLE
Use tox 3 as a temporary workaround.

### DIFF
--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -1,4 +1,6 @@
 pip
 setuptools
 virtualenv
-tox
+# "pip list" in tox 4 has an issue in Fedora 36, 35 cases.
+# https://github.com/tox-dev/tox/issues/2737
+tox<4


### PR DESCRIPTION
The tox 4 has an issue below. As a workaround to make the CI green, we use tox 3.

A sub process "pip list" by "subprocess.Popen, communicate()" returns empty in Fedora 36 container in GitHub Actions.

This PR is a temporary workaround for the https://github.com/junaruga/rpm-py-installer/issues/270 . The tox issue ticket is https://github.com/tox-dev/tox/issues/2737 .
