### PR TITLE
Add a document to explain alternative ways of the rpm-py-installer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 `rpm-py-installer` is to enable [the RPM Python binding](https://github.com/rpm-software-management/rpm/tree/master/python) in any Python environment. The environment can be a non-system Python, a source compiled Python, a Python in a virtualenv, pyenv environment, etc. It installs the Python binding matching the version of the system RPM in a safe manner. The reason for the project's existence is that [the RPM project is not positive to upload the Python binding to PyPI](https://github.com/rpm-software-management/rpm/issues/273), and [the "rpm" name is reserved in PyPI](https://pypi.org/project/rpm).
 
+## Announcements
+
+We are happy to see the `rpm-py-installer` used in the RPM Python ecosystem. However, unfortunately we have a challenge to continue to maintain this project, with following new features of the dependent software and adding new features to meet user's expectations. The `rpm-py-installer` has issues with new other components. The project can survive and thrive by people's contributions. Your pull-requests are welcome. Please consider trying the [alternative ways](docs/alternatives.md) to solve your problems instead of the `rpm-py-installer` if you see the issues.
+
 ## Getting started
 
 `rpm-py-installer` provides several ways to install the RPM Python binding.

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -1,0 +1,42 @@
+# Alternative ways of RPM Python binding
+
+In this document, we introduce alternative ways that may solve your facing challenges.
+
+## Using venv --system-site-packages option
+
+This is the way of using `python -m venv` or `virtualenv` `--system-site-packages` option to give the virtual environment access to the system site packages. It was confirmed on Fedora Linux 37.
+
+Install the system RPM Python binding package.
+
+```
+$ sudo dnf install python3-rpm
+
+$ rpm -q python3-rpm
+python3-rpm-4.18.0-1.fc37.x86_64
+
+$ pip list | grep '^rpm '
+rpm                  4.18.0
+
+$ python -m venv --help
+...
+  --system-site-packages
+                        Give the virtual environment access to the system site-packages
+                        dir.
+...
+```
+
+Then you can load the system `rpm` PyPI package in the virtual environment.
+
+```
+$ python -m venv ./venv --system-site-packages
+
+$ source venv/bin/activate
+
+(venv) $ pip list | grep ^rpm
+rpm                  4.18.0
+...
+```
+
+## Using rpm-shim module from PyPI
+
+See [the rpm PyPI page](https://pypi.org/project/rpm/). It replaces itself with system RPM Python bindings when imported in a virtual environment.


### PR DESCRIPTION
This PR is for the following task at <https://github.com/rpm-py-installer/rpm-py-installer/issues/277#issuecomment-1541505267>. As a result, this PR fixes #277

> Add a text to consider using rpm-shm in README.

Here is the updated README.
https://github.com/rpm-py-installer/rpm-py-installer/blob/wip/doc-alternative/README.md
